### PR TITLE
Fixes stability of unit tests

### DIFF
--- a/client/src/test/resources/simplelogger.properties
+++ b/client/src/test/resources/simplelogger.properties
@@ -23,7 +23,7 @@
 # Logging detail level for a SimpleLogger instance named "xxxxx".
 # Must be one of ("trace", "debug", "info", "warn", or "error").
 # If not specified, the default logging detail level is used.
-org.slf4j.simpleLogger.log.org.ehrbase.client=debug
+org.slf4j.simpleLogger.log.org.ehrbase.client=info
 # Set to true if you want the current date and time to be included in output messages.
 # Default is false, and will output the number of milliseconds elapsed since startup.
 #org.slf4j.simpleLogger.showDateTime=false


### PR DESCRIPTION
Sets client unit test logging to info level. This seems to fix VM crashes, due to a very high amount of logging.