### PR TITLE
Changes group ID to allow EHRbase build w/ locally installed SDK deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,19 @@
 version: 2.1
 
-orbs:
-  maven: circleci/maven@1.0.1
-  openjdk-install: cloudesire/openjdk-install@1.2.3
+# OVERVIEW - What this CI pipeline does:
+# 1. build & (unit)test the SDK
+# 2. build & (unit)test EHRbase w/ SDK (as local dependency)
+# 3. run all integation tests suites
+#    - setup test environment
+#    - execute robot tests
+# 4. publish snapshot & release versions on jitpack.io
+#    - after manually creating a release (via Github UI) based on one of these versions
+#    - jitpack will build related artifacts on demand
 
 
 workflows:
 
+  # WORKFLOW 1/4) Build & Test the SDK
   build_and_test_SDK:
     jobs:
       - build-openEHR_SDK:
@@ -15,6 +22,8 @@ workflows:
               ignore:
                 - master
                 - develop
+                - release
+
       - build-EHRbase:
           requires:
             - build-openEHR_SDK
@@ -23,7 +32,9 @@ workflows:
               ignore:
                 - master
                 - develop
-      - run-CONTRIBUTION-test:
+                - release
+
+      - COMPOSITION-tests-1:
           context: org-global
           requires:
             - build-EHRbase
@@ -32,33 +43,183 @@ workflows:
               ignore:
                 - master
                 - develop
-      - generate-test-report:
+                - release
+
+      - COMPOSITION-tests-2:
+          context: org-global
           requires:
-            - run-CONTRIBUTION-test
+            - build-EHRbase
           filters:
             branches:
               ignore:
                 - master
                 - develop
+                - release
+
+      - COMPOSITION-tests-3:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - COMPOSITION-tests-4:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - CONTRIBUTION-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - DIRECTORY-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - EHRSERVICE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+      
+      - EHRSTATUS-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+      
+      - KNOWLEDGE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - QUERYSERVICE-tests-1:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - QUERYSERVICE-tests-2:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
+      - ROBOT-TEST-REPORT:
+          context: org-global
+          requires:
+            - COMPOSITION-tests-1
+            - COMPOSITION-tests-2
+            - COMPOSITION-tests-3
+            - COMPOSITION-tests-4
+            - CONTRIBUTION-tests
+            - DIRECTORY-tests
+            - EHRSERVICE-tests
+            - EHRSTATUS-tests
+            - KNOWLEDGE-tests
+            - QUERYSERVICE-tests-1
+            - QUERYSERVICE-tests-2
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
 
+
+  # WORKFLOW 2/4) Publish Git tags for SNAPSHOT releases
   deploy-snapshot-release:
     when:
-      and: # All must be true to trigger
+      and:
         - equal: [ develop, << pipeline.git.branch >> ]
+        # - equal: [ SNAPSHOT, << pipeline.git.tag >> ]
     jobs:
-      - deploy-snapshot:
+      - publish-snapshot:
           filters:
             tags:
-              ignore: /^v.*/
+              ignore:
+                # - /^v.*/
+                - /SNAPSHOT.*/
 
 
+
+  # WORKFLOW 3/4) Publish Git tag for (stable) releases
   deploy-stable-release:
     when:
-      and: # All must be true to trigger
-        - equal: [ master, << pipeline.git.branch >> ]
+      and:
+        - equal: [ release, << pipeline.git.branch >> ]
     jobs:
-      - deploy-stable-release
+      - publish-release
+
+
+
+  # # WORKFLOW 4/4) Update SDK version in EHRbase's POM /w lastest stable release
+  # update-ehrbase-sdk-dependency:
+  #   when:
+  #     and:
+  #       - equal: [ master, << pipeline.git.branch >> ]
+  #   jobs:
+  #     - approve-sdk-version-update:
+  #         type: approval
+  #     - update-ehrbase-sdk-dependency:
+  #         requires:
+  #           - approve-sdk-version-update
+
+
+
+
+
 
 
 jobs:
@@ -71,195 +232,252 @@ jobs:
   #   88,   ,d88   Y8a.    .a8P   88      a8P  Y8a     a8P
   #    "Y8888P"     `"Y8888Y"'    88888888P"    "Y88888P"
 
-  build-openEHR_SDK:
-    working_directory: ~/projects/openEHR_SDK
-    docker:
-      # Primary container w/ Maven & Java JDK
-      - image: cimg/openjdk:11.0
 
+  build-openEHR_SDK:
+    executor: docker-python3-java11
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
       - checkout
-      - run:
-          name: Generate Cache Checksum for openEHR_SDK Dependencies
-          command: find . -name 'pom.xml' | sort | xargs cat > /tmp/openEHR_SDK_maven_cache_seed
-      - restore_cache:
-          key: openEHR_SDK-{{ checksum "/tmp/openEHR_SDK_maven_cache_seed" }}
-      - run:
-          name: Maven build, test, install openEHR_SDK
-          command: mvn install dependency:go-offline -Dmaven.javadoc.skip=true
-      - save_cache:
-          key: openEHR_SDK-{{ checksum "/tmp/openEHR_SDK_maven_cache_seed" }}
-          paths:
-          - ~/.m2
-      - store_test_results:
-          path: client/target/surefire-reports
-      - persist_to_workspace:
-          root: /home/circleci
-          paths:
-            - .m2
+      - cache-out-sdk-m2-dependencies
+      - build-and-test-sdk
+      - cache-in-sdk-m2-dependencies
+      - save-sdk-unittest-results
+      - save-sdk-workspace
+      #-----------------------------------#---------------(use this steps for pipeline debugging only)
+      # - run: echo mock build SDK        # 
+      # - cache-out-sdk-workspace         #
+      # - cache-in-sdk-workspace          #
 
 
   build-EHRbase:
-    working_directory: ~/projects
-    docker:
-      # Primary container w/ Maven & Java JDK
-      # NOTE: all commands run here
-      - image: cimg/openjdk:11.0
-
-      # Secondary (service) container w/ PostgreSQL DB
-      # NOTE: DB is available at `host: localhost`
-      - image: ehrbaseorg/ehrbase-postgres:latest
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
       - checkout
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Git clone EHRbase repo
-          command: |
-            ls -la
-            git clone git@github.com:ehrbase/ehrbase.git
-            cd ~/projects/ehrbase
-            mvn versions:set-property -Dproperty=ehrbase.sdk.version -DnewVersion=0.3.1-SNAPSHOT
-      - run:
-          name: Generate Cache Checksum for EHRbase Dependencies
-          command: find ~/projects/ehrbase -name 'pom.xml' | sort | xargs cat > /tmp/EHRbase_maven_cache_seed
-      - restore_cache:
-          key: EHRbase-{{ checksum "/tmp/EHRbase_maven_cache_seed" }}
-      - run:
-          name: Maven build EHRbase
-          command: |
-            cd ~/projects/ehrbase
-            mvn package dependency:go-offline -DskipTests -Dmaven.javadoc.skip=true
-      - save_cache:
-          key: EHRbase-{{ checksum "/tmp/EHRbase_maven_cache_seed" }}
-          paths:
-          - ~/.m2
-      - persist_to_workspace:
-          root: /home/circleci
-          paths:
-            - projects/ehrbase
+      - restore-sdk-workspace
+      - git-clone-ehrbase-repo
+      - cache-out-ehrbase-m2-dependencies
+      - force-ehrbase-to-use-local-sdk-version
+      - build-and-test-ehrbase
+      - cache-in-ehrbase-m2-dependencies
+      - save-ehrbase-workspace
+      #-----------------------------------#---------------(use this steps for pipeline debugging only
+      # - run: echo MOCKED JOB            #
+      # - cache-in-ehrbase-workspace      #
 
 
-  run-CONTRIBUTION-test:
-    working_directory: ~/projects
-    docker:
-      # Primary container w/ Maven & Java JDK
-      - image: cimg/openjdk:11.0
-
-        # TODO: RESTORE THIS
-        # machine:
-        #   image: ubuntu-1604:201903-01
-
+  COMPOSITION-tests-1:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
-      - run: echo "run integration tests job mock"
-      # - openjdk-install/openjdk:
-      #     version: 11
-      # - run-robot-tests:
-      #     include-tags: "CONTRIBUTION"
-      #     test-suite-path: "CONTRIBUTION_TESTS"
-      #     test-suite-name: "CONTRIBUTION"
-      
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "compositionANDjson1"
+          test-suite-path: "COMPOSITION_TESTS"
+          test-suite-name: "COMPOSITION_1"
 
-  generate-test-report:
-    docker:
-      - image: cimg/openjdk:11.0
+  COMPOSITION-tests-2:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
-      - run: echo "generate test report job mock"
-  
-  
-  deploy-snapshot:
-    docker:
-      - image: cimg/openjdk:11.0
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "compositionANDjson2"
+          test-suite-path: "COMPOSITION_TESTS"
+          test-suite-name: "COMPOSITION_2"
+
+  COMPOSITION-tests-3:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - b7:59:8b:46:65:4e:37:d9:b1:21:30:90:df:9c:c8:dd
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "compositionANDxml1"
+          test-suite-path: "COMPOSITION_TESTS"
+          test-suite-name: "COMPOSITION_3"
+
+  COMPOSITION-tests-4:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "compositionANDxml2"
+          test-suite-path: "COMPOSITION_TESTS"
+          test-suite-name: "COMPOSITION_4"
+
+  CONTRIBUTION-tests:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "CONTRIBUTION"
+          test-suite-path: "CONTRIBUTION_TESTS"
+          test-suite-name: "CONTRIBUTION"
+
+  DIRECTORY-tests:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "directory"
+          test-suite-path: "DIRECTORY_TESTS"
+          test-suite-name: "DIRECTORY"
+
+  EHRSERVICE-tests:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "EHR_SERVICE"
+          test-suite-path: "EHR_SERVICE_TESTS"
+          test-suite-name: "EHR_SERVICE"
+
+  EHRSTATUS-tests:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "EHR_STATUS"
+          test-suite-path: "EHR_STATUS_TESTS"
+          test-suite-name: "EHR_STATUS"
+
+  KNOWLEDGE-tests:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "KNOWLEDGE"
+          test-suite-path: "KNOWLEDGE_TESTS"
+          test-suite-name: "KNOWLEDGE"
+
+  QUERYSERVICE-tests-1:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "aql_adhoc-queryANDempty_db"
+          test-suite-path: "QUERY_SERVICE_TESTS"
+          test-suite-name: "ADHOC-QUERY-1"
+
+  QUERYSERVICE-tests-2:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      - restore-ehrbase-workspace
+      - start-ehrbase-server
+      - run-robot-tests:
+          include-tags: "aql_adhoc-queryANDloaded_db"
+          test-suite-path: "QUERY_SERVICE_TESTS"
+          test-suite-name: "ADHOC-QUERY-2"
+
+  ROBOT-TEST-REPORT:
+    executor: docker-py3-java11-postgres
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      # - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      # - cache-out-python-requirements                 # TODO: @wlad find a solution: python cache not working yet
+      - restore-test-results-folder
+      - merge-robot-outputs
+
+
+  publish-snapshot:
+    executor: docker-python3-java11
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only!)
+    steps:
       - checkout
-      - run:
-          name: Configure GIT
-          command: |
-            git config --global user.email "ci-bot@ehrbase.org"
-            git config --global user.name "ci-bot"
-            # git config --global push.followTags true
-            git remote -v
+      - configure-git-for-ci-bot
+      - cache-out-versionupdater-dependencies
+      - update-and-publish-snapshot-release-version
+      - cache-in-versionupdater-dependencies
 
-      - restore_cache:
-          key: maven-dep-v1-
-      - run:
-          command: |
-            echo test
-            last_commit="$(git log -1 --pretty=%B | cat)"
-            echo $last_commit
-            shopt -s extglob
-            case $last_commit in
-                ( !(!(*"major"*)|!(*"release"*)) )
-                    echo "deploy major release"
-                    exit 0
-                    ;;
-                ( !(!(*"minor"*)|!(*"release"*)) )
-                    echo "deploy minor release"
-                    exit 0
-                    ;;
-                ( !(!(*"patch"*)|!(*"release"*)) )
-                    echo "deploy patch release"
-                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
-                    SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
-                    git commit -am "released v${SDK_VERSION}-SNAPSHOT [skip ci]"
-                    git tag -a v${SDK_VERSION}-SNAPSHOT -m "v${SDK_VERSION}-SNAPSHOT release"
-                    git push --set-upstream origin develop v${SDK_VERSION}-SNAPSHOT
-                    exit 0
-                    ;;
-                *)
-                    echo "do nothing"
-                    exit 0
-                    ;;
-            esac
-      - save_cache:
-          key: maven-dep-v1-{{ checksum ".circleci/config.yml" }}
-          paths:
-            - ~/.m2
-          
-  
-  
-  deploy-stable-release:
-    docker:
-      - image: cimg/openjdk:11.0
-    steps:
-      - run:
-          command: |
-            echo dpl stbl rls
-  
 
-  deploy-patch-version:
-    executor: maven-executor
+  publish-release:
+    executor: docker-python3-java11
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only!)
     steps:
-      - deploy:
-          versioncommand: mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
-  
-  deploy-minor-version:
-    executor: maven-executor
-    steps:
-      - deploy:
-          versioncommand: mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.\${parsedVersion.incrementalVersion} versions:commit
-  
-  deploy-major-version:
-    executor: maven-executor
-    steps:
-      - deploy:
-          versioncommand: mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.nextMajorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} versions:commit
-  
+      - checkout
+      - configure-git-for-ci-bot
+      - cache-out-versionupdater-dependencies
+      - publish-release-version
 
-# 1. build & (unit)test the SDK
-# 2. build & (unit)test EHRbase w/ SDK (as local dependency)
-#    NOTE: make sure EHRbase is build w/ latest commit to SDK
-# 3. run integation tests
-#    - setup test environment
-#    - execute robot tests
-# 4. deploy (to maven central?)
+
+  update-ehrbase-sdk-dependency:
+    executor: docker-python3-java11
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only!)
+    steps:
+      #-----------------------------------#---------------(use for pipeline debugging only)
+      - run: echo MOCKED JOB            # 
+      # - cache-out-ehrbase-workspace     #
+      #-----------------------------------#
+      # - checkout
+      # - configure-git-for-ci-bot
+      # - cache-out-versionupdater-dependencies
+
+
 
 
 
@@ -276,6 +494,302 @@ commands:
   #     `"Y8888Y"'    `"Y8888Y"'    88     `8'     88  88     `8'     88  d8'          `8b  88      `888  88888888Y"'     "Y88888P"
 
 
+  update-and-publish-snapshot-release-version:
+    steps:
+      - run: sudo apt install maven -y
+      - run:
+          name: Update Snapshot Release Version
+          command: |
+            echo test
+            last_commit="$(git log -1 --pretty=%B | cat)"
+            echo $last_commit
+            case $last_commit in
+                *"[major]"*)
+                
+                    echo "bump major release version"
+                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.nextMajorVersion}.0.0 versions:commit
+                    SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+                    
+                    git commit -am "updated major version to v${SDK_VERSION}-SNAPSHOT [skip ci]"
+                    git checkout -b major-snapshot-update
+                    git merge --strategy=ours develop
+                    git checkout develop
+                    git merge major-snapshot-update
+                    git tag -a v${SDK_VERSION}-SNAPSHOT -m "v${SDK_VERSION}-SNAPSHOT release"
+                    git push --set-upstream origin develop v${SDK_VERSION}-SNAPSHOT
+
+                    exit 0
+                    ;;
+                *"[minor]"*)
+
+                    echo "bump minor release version"
+                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0 versions:commit
+                    SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+                    
+                    git commit -am "updated minor version to v${SDK_VERSION}-SNAPSHOT [skip ci]"
+                    git checkout -b minor-snapshot-update
+                    git merge --strategy=ours develop
+                    git checkout develop
+                    git merge minor-snapshot-update
+                    git tag -a v${SDK_VERSION}-SNAPSHOT -m "v${SDK_VERSION}-SNAPSHOT release"
+                    git push --set-upstream origin develop v${SDK_VERSION}-SNAPSHOT
+
+                    exit 0
+                    ;;
+                *"[patch]"*)
+
+                    echo "bump patch release version"
+                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
+                    SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+                    
+                    git commit -am "updated patch version to v${SDK_VERSION}-SNAPSHOT [skip ci]"
+                    git checkout -b patch-snapshot-update
+                    git merge --strategy=ours develop
+                    git checkout develop
+                    git merge patch-snapshot-update
+                    git tag -a v${SDK_VERSION}-SNAPSHOT -m "v${SDK_VERSION}-SNAPSHOT release"
+                    git push --set-upstream origin develop v${SDK_VERSION}-SNAPSHOT
+
+                    exit 0
+                    ;;
+                *)
+                    echo "This was just a simple merge - no versions updated"
+                    exit 0
+                    ;;
+            esac
+
+
+  publish-release-version:
+    steps:
+      - run: sudo apt install maven -y
+      - run:
+          name: Create and push release version tag
+          command: |
+            git branch
+            SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo $SDK_VERSION
+            git fetch
+            git checkout master
+            git reset --hard release
+            git push origin :release
+            git tag -a v${SDK_VERSION} -m "v${SDK_VERSION} (stable) release"
+            git push --force --set-upstream origin master v${SDK_VERSION}
+
+
+  configure-git-for-ci-bot:
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - b7:59:8b:46:65:4e:37:d9:b1:21:30:90:df:9c:c8:dd
+      - run:
+          name: Configure GIT
+          command: |
+            git config --global user.email "ci-bot@ehrbase.org"
+            git config --global user.name "ci-bot"
+            # git config --global push.followTags true
+            git remote -v
+  
+
+  install-xml-cli-tool:
+    steps:
+      - run:
+          name: Install xmlstarlet to handle XML file from CLI
+          command: |
+            sudo killall -9 apt-get || true
+            sudo apt -y update && sudo apt -y install xmlstarlet=1.6.1-2
+  
+
+  cache-out-versionupdater-dependencies:
+    steps:
+      - restore_cache:
+          key: maven-dep-v1-
+
+  cache-in-versionupdater-dependencies:
+    steps:
+      - save_cache:
+          key: maven-dep-v1-
+          paths:
+            - ~/.m2
+
+
+
+
+  # ///////////////////////////////////////////////////////////////////////////
+  # /// SDK COMMANDS                                                        ///
+  # ///////////////////////////////////////////////////////////////////////////
+  
+  build-and-test-sdk:
+    steps:
+      - run: sudo apt install maven -y
+      - run:
+          name: Maven build, test, install openEHR_SDK
+          command: mvn install dependency:go-offline -Dmaven.javadoc.skip=true
+      - run:
+          name: Save the version number of locally installed SDK into a file
+          command: |
+            SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo $SDK_VERSION > SDK_VERSION
+            cat SDK_VERSION
+
+  cache-out-sdk-m2-dependencies:
+    steps:
+      - run:
+          name: Generate Cache Checksum for openEHR_SDK Dependencies
+          command: find . -name 'pom.xml' | sort | xargs cat > /tmp/openEHR_SDK_maven_cache_seed
+      - restore_cache:
+          key: openEHR_SDK-
+
+  cache-in-sdk-m2-dependencies:
+    steps:
+      - save_cache:
+          key: openEHR_SDK-{{ checksum "/tmp/openEHR_SDK_maven_cache_seed" }}
+          paths:
+          - ~/.m2
+  
+  save-sdk-unittest-results:
+    steps:
+      - store_test_results:
+          path: client/target/surefire-reports
+  
+  save-sdk-workspace:
+    steps:
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - .m2
+            - projects
+
+  restore-sdk-workspace:
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+
+  # WARNING: don't use these two steps in production
+  #          use them for pipeline debugging only!
+  cache-in-sdk-workspace:
+    steps:
+      - save_cache:
+          key: sdk-workspace-cache
+          paths:
+            - .
+  cache-out-sdk-workspace:
+    steps:
+      - restore_cache:
+          key: sdk-workspace-cache
+
+
+
+
+
+  # ///////////////////////////////////////////////////////////////////////////
+  # /// EHRBASE COMMANDS                                                    ///
+  # ///////////////////////////////////////////////////////////////////////////
+
+  git-clone-ehrbase-repo:
+    steps:
+      - run:
+          name: Git clone EHRbase repo
+          command: |
+            git clone git@github.com:ehrbase/ehrbase.git
+            ls -la
+  
+  build-and-test-ehrbase:
+    steps:
+      - run: sudo apt install maven -y
+      - run:
+          name: Maven build EHRbase
+          command: |
+            cd ~/projects/ehrbase
+            mvn package dependency:go-offline -Dmaven.javadoc.skip=true
+
+  cache-in-ehrbase-m2-dependencies:
+    steps:
+      - save_cache:
+          key: EHRbase-{{ checksum "/tmp/EHRbase_maven_cache_seed" }}
+          paths:
+            - ~/.m2
+  
+  cache-out-ehrbase-m2-dependencies:
+    steps:
+      - run:
+          name: Generate Cache Checksum for EHRbase Dependencies
+          command: find ~/projects/ehrbase -name 'pom.xml' | sort | xargs cat > /tmp/EHRbase_maven_cache_seed
+      - restore_cache:
+          key: EHRbase-
+
+  save-ehrbase-workspace:
+    steps:
+    - persist_to_workspace:
+        root: /home/circleci
+        paths:
+          - projects/ehrbase
+
+  restore-ehrbase-workspace:
+    description: Attach EHRbase repo containing target folder and tests back to workspace
+    steps:
+      - run: ls -la
+      - attach_workspace:
+          at: /home/circleci/
+      - run: ls -la ehrbase
+
+  force-ehrbase-to-use-local-sdk-version:
+    steps:
+      - install-xml-cli-tool
+      - run:
+          name: Adjust SDK version number in EHRbase's pom
+          command: |
+            SDK_VERSION=$(cat ~/projects/SDK_VERSION)
+            echo $SDK_VERSION
+            cd ~/projects/ehrbase
+            xmlstarlet edit --inplace -N my=http://maven.apache.org/POM/4.0.0 -u my:project/my:version -v $SDK_VERSION pom.xml
+    
+  # WARNING: don't use these two steps in production
+  #          use them for pipeline debugging only!
+  cache-in-ehrbase-workspace:
+    steps:
+      - save_cache:
+          key: ehrbase-workspace-cache-v3
+          paths:
+            - ehrbase
+  cache-out-ehrbase-workspace:
+    steps:
+      - restore_cache:
+          key: ehrbase-workspace-cache-v3
+
+
+
+
+
+  #                            88
+  #                            88                         ,d             ,d                             ,d
+  #                            88                         88             88                             88
+  #   8b,dPPYba,   ,adPPYba,   88,dPPYba,    ,adPPYba,  MM88MMM        MM88MMM  ,adPPYba,  ,adPPYba,  MM88MMM  ,adPPYba,
+  #   88P'   "Y8  a8"     "8a  88P'    "8a  a8"     "8a   88             88    a8P_____88  I8[    ""    88     I8[    ""
+  #   88          8b       d8  88       d8  8b       d8   88             88    8PP"""""""   `"Y8ba,     88      `"Y8ba,
+  #   88          "8a,   ,a8"  88b,   ,a8"  "8a,   ,a8"   88,            88,   "8b,   ,aa  aa    ]8I    88,    aa    ]8I
+  #   88           `"YbbdP"'   8Y"Ybbd8"'    `"YbbdP"'    "Y888          "Y888  `"Ybbd8"'  `"YbbdP"'    "Y888  `"YbbdP"'
+  #
+  # ///////////////////////////////////////////////////////////////////////////
+  # /// ROBOT INTEGRATION TESTS COMMANDS                                    ///
+  # ///////////////////////////////////////////////////////////////////////////
+
+  start-ehrbase-server:
+    steps:
+      # - openjdk-install/openjdk:    # (use w/ machine executor only)
+      #     version: 11               #
+      - run: sudo apt install maven -y
+      - run:
+          name: Start EHRbase server
+          background: true
+          command: |
+            ls -la
+            cd ehrbase
+            EHRbase_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo ${EHRbase_VERSION}
+            java -jar application/target/application-${EHRbase_VERSION}.jar --cache.enabled=false > log
+
+
+  # USE THIS COMMAND W/ DOCKER EXECUTOR ONLY!!! 
   run-robot-tests:
     description: Run integration tests written in Robot Framework
     parameters:
@@ -289,11 +803,14 @@ commands:
         description: Titel of generated Robot Log/Report.html
         type: string
     steps:
-      - attach-ehrbase-repo-to-workspace
-      # - configure-python-version
-      # - restore-pip-cache
+      # - cache-out-python-requirements
       - install-python-requirements
-      - run: pip list
+      - run: jps
+      - run:
+          name: Wait until EHRbase server is ready
+          command: |
+            cd ehrbase
+            grep -m 1 "Started EhrBase in" <(tail -f log)
       - run:
           name: EXECUTE ROBOT COMMAND
           no_output_timeout: 30m
@@ -309,13 +826,56 @@ commands:
                   --flattenkeywords name:_resources.* \
                   --outputdir results/<< parameters.test-suite-name >> \
                   --name << parameters.test-suite-name >> \
+                  -v nodocker \
                   robot/<< parameters.test-suite-path >>/
-      # - save-pip-cache
-      - persist-test-results-folder
+      # - cache-in-python-requirements
+      - save-test-results-folder
       - store_test_results:
           path: ~/projects/ehrbase/tests/results/
       - store_artifacts:
           path: ~/projects/ehrbase/tests/results/
+
+
+  # # USE THIS COMMAND W/ MACHINE EXECUTOR ONLY!!!
+  # run-robot-tests:
+  #   description: Run integration tests written in Robot Framework
+  #   parameters:
+  #     include-tags:
+  #       description: Which tests to inclue by TAGs (Robot syntax applies!)
+  #       type: string
+  #     test-suite-path:
+  #       description: Target test-suite given by it's folder name e.g. COMPOSITION_TESTS
+  #       type: string
+  #     test-suite-name:
+  #       description: Titel of generated Robot Log/Report.html
+  #       type: string
+  #   steps:
+  #     - configure-python-version
+  #     # - cache-out-python-requirements
+  #     - install-python-requirements
+  #     - run: pip list
+  #     - run:
+  #         name: EXECUTE ROBOT COMMAND
+  #         no_output_timeout: 30m
+  #         command: |
+  #           cd ~/projects/ehrbase/tests
+  #           robot --include << parameters.include-tags >> \
+  #                 --exclude TODO -e future -e obsolete -e libtest \
+  #                 --console dotted \
+  #                 --loglevel TRACE \
+  #                 --noncritical not-ready \
+  #                 --flattenkeywords for \
+  #                 --flattenkeywords foritem \
+  #                 --flattenkeywords name:_resources.* \
+  #                 --outputdir results/<< parameters.test-suite-name >> \
+  #                 --name << parameters.test-suite-name >> \
+  #                 robot/<< parameters.test-suite-path >>/
+  #     # - cache-in-python-requirements
+  #     - save-test-results-folder
+  #     - store_test_results:
+  #         path: ~/projects/ehrbase/tests/results/
+  #     - store_artifacts:
+  #         path: ~/projects/ehrbase/tests/results/
 
   
   configure-python-version:
@@ -330,17 +890,17 @@ commands:
   install-python-requirements:
     description: Install Python requirements
     steps:
-      - configure-python-version
-      # - restore-pip-cache
+      # - cache-out-python-requirements
       - run:
           name: Install Python requirements
           command: |
+            python --version
             python -c "import site; print(site.getsitepackages())"
             pip install -r ~/projects/ehrbase/tests/requirements.txt
-      # - save-pip-cache
+      # - cache-in-python-requirements
   
 
-  save-pip-cache:
+  cache-in-python-requirements:
     description: Save all caches in interation tests job
     steps:
       - run:
@@ -356,24 +916,15 @@ commands:
             - /opt/circleci/.pyenv/versions/3.7.0/lib/python3.7/site-packages
 
 
-  restore-pip-cache:
+  cache-out-python-requirements:
     description: Restore all caches in interation tests job
     steps:
       - restore_cache:
           keys:
             - pip-v1-
-  
-
-  attach-ehrbase-repo-to-workspace:
-    description: Attach EHRbase repo containing target folder and tests back to workspace
-    steps:
-      - run: ls -la
-      - attach_workspace:
-          at: /home/circleci/
-      - run: ls -la ehrbase
 
 
-  persist-test-results-folder:
+  save-test-results-folder:
     description: Persist Robot tests folder to workspace
     steps:
       - run:
@@ -386,133 +937,169 @@ commands:
             - projects/ehrbase/tests/results
 
 
-  attach-test-results-folder:
+  restore-test-results-folder:
     description: Attach Robot tests folder back to workspace
     steps:
       - attach_workspace:
           at: /home/circleci/
-  
 
-  bump-version:
-    parameters:
-      versioncommand:
-        type: string
+
+  merge-robot-outputs:
+    description: Merge Robot Results from Parallel Tests
     steps:
-      # - attach_workspace:
-      #     at: .
-      # - restore_cache:
-      #     key: auto-deploy-test-{{ checksum ".circleci/config.yml" }}
+      # - configure-python-version                    # (use w/ machine executor only)
       - run:
-          name: Bump version
           command: |
-            << parameters.versioncommand >>
-            # DskipTests -Dspotbugs.skip=true
-            echo "Succesfully released new version"
-      # - save_cache:
-      #   paths:
-      #     - ~/.m2
-      #   key: auto-deploy-test-{{ checksum ".circleci/config.yml" }}
-
-  foo-snapshot-release:
-    steps:
+            pip install robotframework
       - run:
-          name: Release new version to Maven Central
+          name: POST PROCESS & MERGE TEST RESULTS
+          when: always
           command: |
-            echo "Starting new release..."
-            << parameters.versioncommand >>
-            mvn -s .circleci/maven-release-settings.xml clean deploy -DdeployAtEnd=true -DperformRelease=true -DskipTests -Dspotbugs.skip=true
-            echo "Succesfully released new version"
+            cd ehrbase/tests
 
-  foo:
-    steps:
+            # Create Log/Report with ALL DETAILS
+            rebot --outputdir results \
+                  --name EHRbase \
+                  --exclude TODO -e future -e obsolete -e libtest \
+                  --removekeywords for \
+                  --removekeywords wuks \
+                  --loglevel TRACE \
+                  --noncritical not-ready \
+                  --output EHRbase-output.xml \
+                  --log EHRbase-log.html \
+                  --report EHRbase-report.html \
+                  results/*/*.xml
       - run:
-          name: Get last commit message
+          name: GENERATE TEST SUMMARY
+          when: always
           command: |
-            last_commit="$(git log -1 --pretty=%B | cat)"
+            cd ehrbase/tests
+
+            # Create JUNIT report from merged results
+            rebot --outputdir results \
+                  --exclude TODO -e future -e obsolete -e libtest \
+                  --noncritical not-ready \
+                  --xunit junit-output.xml --xunitskipnoncritical \
+                  --log NONE \
+                  --report NONE \
+                  results/EHRbase-output.xml
+      - save-test-results-folder
+      - store_test_results:
+          path: ~/projects/ehrbase/tests/results/
+      - store_artifacts:
+          path: ~/projects/ehrbase/tests/results/
 
 
-      - run:
-          name: Check if commit message contains 'some-string'
-          command: |
-            if [[ ${last_commit} == *[some-string]* ]]
-            then
-              # Generate and publish API docs
-            fi
-
-            if [[ ${last_commit} == *"minor"* ]]; then echo hello wlad; fi
-
-            STR='GNU/Linux is an operating system'
-            SUB='Linux'
-
-            case $STR in
-
-              *"$SUB"*)
-                echo -n "It's there."
-                ;;
-            esac
-
-            case $last_commit in 
-              ( !(!(*"major"*)|!(*"release"*)) )
-                echo "deploy major release"
-                ;;
-              ( !(!(*"ninor"*)|!(*"release"*)) )
-                echo "deploy minor release"
-                ;;
-              ( !(!(*"patch"*)|!(*"release"*)) )
-                echo "deploy patch release"
-                ;;
-              *)
-                echo "do nothing"
-                exit 0
-                ;;
-            esac
 
 
-  # install-openjdk:
-  #   parameters:
-  #     version:
-  #       type: integer
-  #       default: 8
-  #     cache_version:
-  #       type: integer
-  #       default: 1
+
+# ///////////////////////////////////////////////////////////////////////////
+# /// CIRCLECI META                                                       ///
+# ///////////////////////////////////////////////////////////////////////////
+
+
+orbs:
+  maven: circleci/maven@1.0.1
+  openjdk-install: cloudesire/openjdk-install@1.2.3
+
+executors:
+  docker-python3-java11:
+    working_directory: ~/projects
+    docker:
+      - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
+
+  docker-py3-java11-postgres:
+    working_directory: ~/projects
+    docker:
+      - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
+      - image: ehrbaseorg/ehrbase-postgres:latest
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
+  vm-ubuntu-1604:
+    working_directory: ~/projects
+    # working_directory: /mnt/ramdisk      # TODO: @wlad TEST THIS FOR POSIBLE
+    machine:                               #             SPEED IMPROVEMENT !!!
+      image: ubuntu-1604:201903-01
+
+
+
+
+
+
+
+
+
+
+# oooooooooo.        .o.         .oooooo.   oooo    oooo ooooo     ooo ooooooooo.
+# `888'   `Y8b      .888.       d8P'  `Y8b  `888   .8P'  `888'     `8' `888   `Y88.
+#  888     888     .8"888.     888           888  d8'     888       8   888   .d88'
+#  888oooo888'    .8' `888.    888           88888[       888       8   888ooo88P'
+#  888    `88b   .88ooo8888.   888           888`88b.     888       8   888
+#  888    .88P  .8'     `888.  `88b    ooo   888  `88b.   `88.    .8'   888
+# o888bood8P'  o88o     o8888o  `Y8bood8P'  o888o  o888o    `YbodP'    o888o
+#
+# [ BACKUP ]
+
+  # Example-how-to-use-INSTALL-JAVA11-ORB:
+  #   executor: vm-ubuntu-1604
+  #   steps:
+  #     - run: echo "run integration tests job mock"
+  #     - openjdk-install/openjdk:
+  #         version: 11
+  #     - restore-ehrbase-workspace
+  #     - run-robot-tests:
+  #         include-tags: "CONTRIBUTION"
+  #         test-suite-path: "CONTRIBUTION_TESTS"
+  #         test-suite-name: "CONTRIBUTION"
+
+
+
+  # force-ehrbase-to-use-local-sdk-version:
+  #   steps:
+  #     - run: sudo apt install maven -y
+  #     - run:
+  #         name: Adjust SDK version number in EHRbase's pom
+  #         description: |
+  #           We have to provide the version of locally build openEHR_SDK in EHRbase's POM
+  #           to make sure that EHRbase builds succesfully w/ latest changes applied to the SDK.
+  #           "mvn versions:set-property" is an simple way to achieve exactly that. Ufortunately
+  #           it triggers a check for SDK dependency updates from jitpack.io
+  #           which can take up to 15 minutes!
+
+  #           Using Maven's -o (for offline) flag can help to prevent check for update but
+  #           it fails when dependencies are not cached first.
+  #           After caching dependencies it works but not 100% reliable.
+
+  #           As a more robust solution install xmlstarlet (a cli tool to handle XML) and 
+  #           use it as a fallback if the 'mvn -o' approach starts to fail.
+  #         command: |
+  #           SDK_VERSION=$(cat ~/projects/SDK_VERSION)
+  #           echo $SDK_VERSION
+  #           cd ~/projects/ehrbase
+  #           mvn versions:set-property -Dproperty=ehrbase.sdk.version -DnewVersion=$SDK_VERSION -o
+
+
+
+  # command-check-commit-message-contains-string:
   #   steps:
   #     - run:
-  #         name: Workaround for running apt behind the scene
+  #         name: Check if commit message contains 'some-string'
   #         command: |
-  #           sudo killall -9 apt-get || true
-  #     # - run:
-  #     #     name: Switch to US mirror for faster performances
-  #     #     command: sudo sed -i 's/\/\/archive.ubuntu.com/\/\/us.archive.ubuntu.com/g' /etc/apt/sources.list
-  #     - run:
-  #         name: Add openjdk-r PPA
-  #         command: |
-  #           sudo add-apt-repository ppa:openjdk-r/ppa
-  #           sudo apt-get update
-  #     - run:
-  #         name: Generate cache version
-  #         command: |
-  #           apt-cache policy openjdk-<< parameters.version >>-jdk | grep 'Candidate:' | cut -d' ' -f4 > .openjdk_version
-  #           cat .openjdk_version
-  #     - restore_cache:
-  #         keys:
-  #         - apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
-  #     - run:
-  #         name: Create temp directory if restore cache didn't
-  #         command: mkdir -p /tmp/archives
-  #     - run:
-  #         name: Restore apt cache
-  #         command: sudo rsync -av /tmp/archives/ /var/cache/apt/archives/
-  #     - run:
-  #         name: Install openjdk-<< parameters.version >>-jdk
-  #         command: sudo apt-get install -y openjdk-<< parameters.version >>-jdk
-  #     - run: 
-  #         name: Make installed openjdk the default Java version
-  #         command: sudo update-java-alternatives --set java-1.<< parameters.version >>.0-openjdk-amd64
-  #     - run:
-  #         name: Prepare to save apt cache
-  #         command: rsync -av /var/cache/apt/archives/*.deb /tmp/archives/
-  #     - save_cache:
-  #         key: apt-cache-{{ checksum ".openjdk_version" }}-v<< parameters.cache_version >>
-  #         paths:
-  #         - /tmp/archives
+  #           if [[ ${last_commit} == *[some-string]* ]]
+  #           then
+  #             # Generate and publish API docs
+  #           fi
+
+  #           if [[ ${last_commit} == *"minor"* ]]; then echo hello wlad; fi
+
+  #           STR='GNU/Linux is an operating system'
+  #           SUB='Linux'
+
+  #           case $STR in
+
+  #             *"$SUB"*)
+  #               echo -n "It's there."
+  #               ;;
+  #           esac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,11 +206,11 @@ jobs:
                     ;;
                 ( !(!(*"patch"*)|!(*"release"*)) )
                     echo "deploy patch release"
-                    mvn build-helper:parse-version versions:set -DnewVersion=v\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT versions:commit
+                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
                     SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
-                    git commit -am "released ${SDK_VERSION} [skip ci]"
-                    git tag -a ${SDK_VERSION} -m "release ${SDK_VERSION}"
-                    git push --set-upstream origin develop ${SDK_VERSION}
+                    git commit -am "released v${SDK_VERSION}-SNAPSHOT [skip ci]"
+                    git tag -a v${SDK_VERSION}-SNAPSHOT -m "v${SDK_VERSION}-SNAPSHOT release"
+                    git push --set-upstream origin develop v${SDK_VERSION}-SNAPSHOT
                     exit 0
                     ;;
                 *)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,12 +206,11 @@ jobs:
                     ;;
                 ( !(!(*"patch"*)|!(*"release"*)) )
                     echo "deploy patch release"
-                    mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
-                    echo "TODO - deploy to jitpack command goes here"
+                    mvn build-helper:parse-version versions:set -DnewVersion=v\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT versions:commit
                     SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
-                    git commit -am "released v${SDK_VERSION}-SNAPSHOT [skip ci]"
-                    git tag -a v${SDK_VERSION} -m "release v${SDK_VERSION}-SNAPSHOT"
-                    git push --set-upstream origin develop v${SDK_VERSION}
+                    git commit -am "released ${SDK_VERSION} [skip ci]"
+                    git tag -a ${SDK_VERSION} -m "release ${SDK_VERSION}"
+                    git push --set-upstream origin develop ${SDK_VERSION}
                     exit 0
                     ;;
                 *)

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -43,7 +43,7 @@
 
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>opt-1.4</artifactId>
         </dependency>
         <dependency>
@@ -51,16 +51,16 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+           <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>terminology</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>response-dto</artifactId>
         </dependency>
         <dependency>
@@ -102,7 +102,7 @@
 
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
 
         </dependency>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -32,7 +32,7 @@
     <artifactId>generator</artifactId>
     <dependencies>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>client</artifactId>
         </dependency>
 
@@ -54,7 +54,7 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
         </dependency>
     </dependencies>

--- a/opt-1.4/pom.xml
+++ b/opt-1.4/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/opt-1.4/pom.xml
+++ b/opt-1.4/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.ehrbase.sdk</groupId>
+    <groupId>com.github.ehrbase.openEHR_SDK</groupId>
     <artifactId>root</artifactId>
     <packaging>pom</packaging>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>v0.3.2-SNAPSHOT</version>
     <modules>
         <module>client</module>
         <module>generator</module>
@@ -113,42 +113,42 @@
         <dependencies>
             <!-- modules -->
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>client</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>generator</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>response-dto</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>opt-1.4</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>serialisation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>terminology</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ehrbase.sdk</groupId>
+                <groupId>com.github.ehrbase.openEHR_SDK</groupId>
                 <artifactId>test-data</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.github.ehrbase.openEHR_SDK</groupId>
     <artifactId>root</artifactId>
     <packaging>pom</packaging>
-    <version>v0.3.2-SNAPSHOT</version>
+    <version>0.3.5</version>
     <modules>
         <module>client</module>
         <module>generator</module>

--- a/response-dto/pom.xml
+++ b/response-dto/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/response-dto/pom.xml
+++ b/response-dto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/serialisation/pom.xml
+++ b/serialisation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/serialisation/pom.xml
+++ b/serialisation/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -91,7 +91,7 @@
 
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
         </dependency>
         <dependency>

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -36,7 +36,7 @@
             <artifactId>archie</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>

--- a/test-data/pom.xml
+++ b/test-data/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-data/pom.xml
+++ b/test-data/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -23,8 +23,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
-        <groupId>org.ehrbase.sdk</groupId>
-        <version>0.3.1-SNAPSHOT</version>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>v0.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,11 +32,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>terminology</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>opt-1.4</artifactId>
         </dependency>
         <dependency>
@@ -50,12 +50,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.ehrbase.sdk</groupId>
+           <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>serialisation</artifactId>
             <scope>test</scope>
         </dependency>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>v0.3.2-SNAPSHOT</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
this one is based on commit d97d209 which is used in EHRbase repo on development branch: `<ehrbase.sdk.version>d97d209</ehrbase.sdk.version>`

Using <ehrbase.sdk.version>v0.3.2-SNAPSHOT</ehrbase.sdk.version> in EHRbase's main pom works in both cases:

  - locally (after `mvn install SDK) und and
  - remotely (with clean ~/.m2 folder, then SDK dependencies are pulled from jitpack.io)