### PR TITLE
Fixes usage of content type as accecpt header

### DIFF
--- a/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpoint.java
+++ b/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpoint.java
@@ -56,8 +56,7 @@ import java.net.URI;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
 
-import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.OBJECT_MAPPER;
-import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.checkStatus;
+import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.*;
 import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestCompositionEndpoint.addVersion;
 
 public class DefaultRestAqlEndpoint implements AqlEndpoint {
@@ -92,7 +91,7 @@ public class DefaultRestAqlEndpoint implements AqlEndpoint {
         URI uri = defaultRestClient.getConfig().getBaseUri().resolve("query/aql");
         try {
             HttpResponse response = Request.Post(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON)
                     .bodyString(OBJECT_MAPPER.writeValueAsString(qMap), ContentType.APPLICATION_JSON)
                     .execute().returnResponse();
             checkStatus(response, HttpStatus.SC_OK, HttpStatus.SC_CREATED, HttpStatus.SC_NO_CONTENT);

--- a/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestClient.java
+++ b/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestClient.java
@@ -55,7 +55,8 @@ import java.util.WeakHashMap;
 
 public class DefaultRestClient implements OpenEhrClient {
 
-    static final String APPLICATION_JSON = "application/json";
+    static final String ACCEPT_APPLICATION_JSON = "application/json";
+    static final String ACCEPT_APPLICATION_XML = "application/xml";
     static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
     private final OpenEhrClientConfig config;
     private final TemplateProvider templateProvider;
@@ -89,7 +90,7 @@ public class DefaultRestClient implements OpenEhrClient {
     static VersionUid httpPost(URI uri, RMObject body) {
         try {
             HttpResponse response = Request.Post(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON)
                     .bodyString(new CanonicalJson().marshal(body), ContentType.APPLICATION_JSON)
                     .execute().returnResponse();
             checkStatus(response, HttpStatus.SC_OK, HttpStatus.SC_CREATED, HttpStatus.SC_NO_CONTENT);
@@ -103,7 +104,7 @@ public class DefaultRestClient implements OpenEhrClient {
     static VersionUid httpPut(URI uri, Locatable body, VersionUid versionUid) {
         try {
             HttpResponse response = Request.Put(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON)
                     .addHeader(HttpHeaders.IF_MATCH, versionUid.toString())
                     .bodyString(new CanonicalJson().marshal(body), ContentType.APPLICATION_JSON)
                     .execute().returnResponse();
@@ -121,7 +122,7 @@ public class DefaultRestClient implements OpenEhrClient {
     static <T> Optional<T> httpGet(URI uri, Class<T> valueType) {
         try {
             HttpResponse response = Request.Get(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON)
                     .execute().returnResponse();
             checkStatus(response, HttpStatus.SC_OK, HttpStatus.SC_NOT_FOUND);
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {

--- a/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestFolderDAO.java
+++ b/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestFolderDAO.java
@@ -49,8 +49,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.OBJECT_MAPPER;
-import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.checkStatus;
+import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.*;
 
 public class DefaultRestFolderDAO implements FolderDAO {
 
@@ -131,7 +130,7 @@ public class DefaultRestFolderDAO implements FolderDAO {
         URI uri = directoryEndpoint.getDefaultRestClient().getConfig().getBaseUri().resolve("query/aql");
         try {
             HttpResponse response = Request.Post(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON)
                     .bodyString(OBJECT_MAPPER.writeValueAsString(qMap), ContentType.APPLICATION_JSON)
                     .execute().returnResponse();
             checkStatus(response, HttpStatus.SC_OK, HttpStatus.SC_CREATED, HttpStatus.SC_NO_CONTENT);

--- a/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestTemplateEndpoint.java
+++ b/client/src/main/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestTemplateEndpoint.java
@@ -40,6 +40,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
+import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.ACCEPT_APPLICATION_JSON;
+import static org.ehrbase.client.openehrclient.defaultrestclient.DefaultRestClient.ACCEPT_APPLICATION_XML;
+
 public class DefaultRestTemplateEndpoint implements TemplateEndpoint {
 
     public static final String DEFINITION_TEMPLATE_ADL_1_4_PATH = "definition/template/adl1.4/";
@@ -59,7 +62,7 @@ public class DefaultRestTemplateEndpoint implements TemplateEndpoint {
             URI uri = defaultRestClient.getConfig().getBaseUri().resolve(new URIBuilder().setPath(defaultRestClient.getConfig().getBaseUri().getPath() + DEFINITION_TEMPLATE_ADL_1_4_PATH + templateId).build());
             logger.debug("Calling Get {}", uri);
             HttpResponse httpResponse = Request.Get(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_XML.toString())
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_XML)
                     .execute()
                     .returnResponse();
 
@@ -101,7 +104,7 @@ public class DefaultRestTemplateEndpoint implements TemplateEndpoint {
         opts.setSaveSyntheticDocumentElement(new QName("http://schemas.openehr.org/v1", "template"));
         try {
             HttpResponse response = Request.Post(uri)
-                    .addHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.toString()).bodyString(
+                    .addHeader(HttpHeaders.ACCEPT, ACCEPT_APPLICATION_JSON).bodyString(
                             operationaltemplate.xmlText(opts), ContentType.APPLICATION_XML)
                     .execute().returnResponse();
             DefaultRestClient.checkStatus(response, HttpStatus.SC_OK, HttpStatus.SC_CREATED, HttpStatus.SC_NO_CONTENT);


### PR DESCRIPTION
The apache httpclient content type constants are designed to be used as
content-type header. They contain charset parameters, which are only
allowed as content-type header. For accept header scenarios there's a
specific accept-charset header.
This charset at the wrong place caused problems.