### PR TITLE
304 add sonar analysis to ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,23 +16,23 @@ workflows:
   # WORKFLOW 1/4) Build & Test the SDK
   build_and_test_SDK:
     jobs:
-      # - build-openEHR_SDK:
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - build-openEHR_SDK:
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - build-EHRbase:
-      #     requires:
-      #       - build-openEHR_SDK
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - build-EHRbase:
+          requires:
+            - build-openEHR_SDK
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
       # - COMPOSITION-tests-1:
       #     context: org-global
@@ -176,14 +176,14 @@ workflows:
       #           - develop
       #           - release
 
-      - run-static-code-analysis:
-          context: org-global
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - run-static-code-analysis:
+      #     context: org-global
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,14 @@ workflows:
                 - develop
                 - release
 
+      - test-openEHR_SDK:
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
+
       - build-EHRbase:
           requires:
             - build-openEHR_SDK
@@ -243,6 +251,7 @@ jobs:
 
 
   build-openEHR_SDK:
+    description: Build and unit test the SDK.
     executor: docker-python3-java11
     # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
@@ -256,6 +265,25 @@ jobs:
       # - run: echo mock build SDK        # 
       # - cache-out-sdk-workspace         #
       # - cache-in-sdk-workspace          #
+  
+
+  test-openEHR_SDK:
+    description: Build and run openEHR_SDK's Java integration tests (w/ EHRbase + DB running).
+    executor: docker-py3-java11-postgres
+    steps:
+      - checkout
+      - cache-out-sdk-m2-dependencies
+      - build-sdk
+      - git-clone-ehrbase-repo
+      - cache-out-ehrbase-m2-dependencies
+      - force-ehrbase-to-use-local-sdk-version
+      - run-java-integration-tests-of-sdk
+      - cache-in-ehrbase-m2-dependencies      
+      - cache-in-sdk-m2-dependencies
+      - save-sdk-unittest-results
+      - save-sdk-integrationtest-results
+      - save-sdk-workspace
+
 
   run-static-code-analysis:
     description: |
@@ -453,6 +481,7 @@ jobs:
           test-suite-path: "QUERY_SERVICE_TESTS"
           test-suite-name: "ADHOC-QUERY-2"
 
+
   ROBOT-TEST-REPORT:
     executor: docker-py3-java11-postgres
     # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
@@ -518,7 +547,7 @@ commands:
 
   update-and-publish-snapshot-release-version:
     steps:
-      - run: sudo apt install maven -y
+      - install-maven
       - run:
           name: Update Snapshot Release Version
           command: |
@@ -583,7 +612,7 @@ commands:
 
   publish-release-version:
     steps:
-      - run: sudo apt install maven -y
+      - install-maven
       - run:
           name: Create and push release version tag
           command: |
@@ -636,15 +665,30 @@ commands:
 
 
 
+
   # ///////////////////////////////////////////////////////////////////////////
   # /// SDK COMMANDS                                                        ///
   # ///////////////////////////////////////////////////////////////////////////
   
+  build-sdk:
+    steps:
+      - install-maven
+      - run:
+          name: Maven build, install openEHR_SDK (skip Tests!)
+          command: mvn install -Dmaven.javadoc.skip=true -Dmaven.test.skip
+      - run:
+          name: Save the version number of locally installed SDK into a file
+          command: |
+            SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo $SDK_VERSION > SDK_VERSION
+            cat SDK_VERSION
+
+
   build-and-test-sdk:
     steps:
-      - run: sudo apt install maven -y
+      - install-maven
       - run:
-          name: Maven build, test, install openEHR_SDK
+          name: Maven build, test (ONLY unit tests), install openEHR_SDK
           command: mvn install dependency:go-offline -Dmaven.javadoc.skip=true
       - run:
           name: Save the version number of locally installed SDK into a file
@@ -652,6 +696,45 @@ commands:
             SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
             echo $SDK_VERSION > SDK_VERSION
             cat SDK_VERSION
+
+
+  build-and-integration-test-sdk:
+    steps:
+      - install-maven
+      - run:
+          name: Maven run only Java integration tests of openEHR_SDK
+          description: |
+            Runs maven test phase using 'slow' profile defined in parent pom.xml
+            This way only the Java integration tests are executed.
+          command: |
+            jps
+            mvn test -Pslow -Dmaven.javadoc.skip=true
+
+
+  run-java-integration-tests-of-sdk:
+    steps:
+      - install-maven
+      - run:
+          name: Maven build EHRbase
+          command: |
+            cd ~/projects/ehrbase
+            mvn package -Dmaven.javadoc.skip=true -Dmaven.test.skip
+      - run:
+          name: Start EHRbase server and run SDK's integration tests
+          description: |
+            Runs maven test phase using 'slow' profile defined in parent pom.xml
+            This way only the Java integration tests are executed.
+          command: |
+            ls -la
+            cd ~/projects/ehrbase
+            EHRbase_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
+            echo ${EHRbase_VERSION}
+            java -jar application/target/application-${EHRbase_VERSION}.jar --cache.enabled=false > log &
+            grep -m 1 "Started EhrBase in" <(tail -f log)
+            cd ..
+            jps
+            mvn test -Pslow -Dmaven.javadoc.skip=true
+
 
   cache-out-sdk-m2-dependencies:
     steps:
@@ -661,18 +744,43 @@ commands:
       - restore_cache:
           key: openEHR_SDK-
 
+
   cache-in-sdk-m2-dependencies:
     steps:
       - save_cache:
           key: openEHR_SDK-{{ checksum "/tmp/openEHR_SDK_maven_cache_seed" }}
           paths:
           - ~/.m2
-  
+
+
   save-sdk-unittest-results:
     steps:
+      - run:
+          name: Save unit test results
+          command: |
+            mkdir -p ~/test-results/unit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/unit/ \;
+          when: always
       - store_test_results:
-          path: client/target/surefire-reports
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/unit
   
+
+  save-sdk-integrationtest-results:
+    steps:
+      - run:
+          name: Save integration test results
+          command: |
+            mkdir -p ~/test-results/integration/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/integration/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/integration
+  
+
   save-sdk-workspace:
     steps:
       - persist_to_workspace:
@@ -681,10 +789,13 @@ commands:
             - .m2
             - projects
 
+
   restore-sdk-workspace:
     steps:
       - attach_workspace:
           at: /home/circleci/
+
+
 
   # WARNING: don't use these two steps in production
   #          use them for pipeline debugging only!
@@ -715,14 +826,16 @@ commands:
             git clone git@github.com:ehrbase/ehrbase.git
             ls -la
   
+
   build-and-test-ehrbase:
     steps:
-      - run: sudo apt install maven -y
+      - install-maven
       - run:
           name: Maven build EHRbase
           command: |
             cd ~/projects/ehrbase
             mvn package dependency:go-offline -Dmaven.javadoc.skip=true
+
 
   cache-in-ehrbase-m2-dependencies:
     steps:
@@ -730,7 +843,8 @@ commands:
           key: EHRbase-{{ checksum "/tmp/EHRbase_maven_cache_seed" }}
           paths:
             - ~/.m2
-  
+
+
   cache-out-ehrbase-m2-dependencies:
     steps:
       - run:
@@ -739,12 +853,14 @@ commands:
       - restore_cache:
           key: EHRbase-
 
+
   save-ehrbase-workspace:
     steps:
     - persist_to_workspace:
         root: /home/circleci
         paths:
           - projects/ehrbase
+
 
   restore-ehrbase-workspace:
     description: Attach EHRbase repo containing target folder and tests back to workspace
@@ -753,6 +869,7 @@ commands:
       - attach_workspace:
           at: /home/circleci/
       - run: ls -la ehrbase
+
 
   force-ehrbase-to-use-local-sdk-version:
     steps:
@@ -764,7 +881,9 @@ commands:
             echo $SDK_VERSION
             cd ~/projects/ehrbase
             xmlstarlet edit --inplace -N my=http://maven.apache.org/POM/4.0.0 -u my:project/my:version -v $SDK_VERSION pom.xml
-    
+  
+
+
   # WARNING: don't use these two steps in production
   #          use them for pipeline debugging only!
   cache-in-ehrbase-workspace:
@@ -777,6 +896,22 @@ commands:
     steps:
       - restore_cache:
           key: ehrbase-workspace-cache-v3
+
+
+
+
+
+# ///////////////////////////////////////////////////////////////////////////
+# /// HELPER COMMANDS                                                    ///
+# ///////////////////////////////////////////////////////////////////////////
+
+  install-maven:
+    description: Install Maven tool only if it's not already installed
+    steps:
+      - run: 
+          name: Install Maven tool
+          command: |
+            [ -f /usr/bin/mvn ] && echo "Maven is already installed." || sudo apt install maven -y
 
 
 
@@ -799,7 +934,8 @@ commands:
     steps:
       # - openjdk-install/openjdk:    # (use w/ machine executor only)
       #     version: 11               #
-      - run: sudo apt install maven -y
+      # - run: sudo apt install maven -y
+      - install-maven
       - run:
           name: Start EHRbase server
           background: true
@@ -1042,7 +1178,7 @@ executors:
 
   vm-ubuntu-1604:
     working_directory: ~/projects
-    # working_directory: /mnt/ramdisk      # TODO: @wlad TEST THIS FOR POSIBLE
+    # working_directory: /mnt/ramdisk      # TODO: @wlad TEST THIS FOR POSSIBLE
     machine:                               #             SPEED IMPROVEMENT !!!
       image: ubuntu-1604:201903-01
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,151 +24,163 @@ workflows:
                 - develop
                 - release
 
-      - build-EHRbase:
+      # - build-EHRbase:
+      #     requires:
+      #       - build-openEHR_SDK
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - COMPOSITION-tests-1:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - COMPOSITION-tests-2:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - COMPOSITION-tests-3:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - COMPOSITION-tests-4:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - CONTRIBUTION-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - DIRECTORY-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - EHRSERVICE-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+      
+      # - EHRSTATUS-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+      
+      # - KNOWLEDGE-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - QUERYSERVICE-tests-1:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - QUERYSERVICE-tests-2:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      # - ROBOT-TEST-REPORT:
+      #     context: org-global
+      #     requires:
+      #       - COMPOSITION-tests-1
+      #       - COMPOSITION-tests-2
+      #       - COMPOSITION-tests-3
+      #       - COMPOSITION-tests-4
+      #       - CONTRIBUTION-tests
+      #       - DIRECTORY-tests
+      #       - EHRSERVICE-tests
+      #       - EHRSTATUS-tests
+      #       - KNOWLEDGE-tests
+      #       - QUERYSERVICE-tests-1
+      #       - QUERYSERVICE-tests-2
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
+
+      - run-static-code-analysis:
+          context: org-global
           requires:
             - build-openEHR_SDK
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - COMPOSITION-tests-1:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - COMPOSITION-tests-2:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - COMPOSITION-tests-3:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - COMPOSITION-tests-4:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - CONTRIBUTION-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - DIRECTORY-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - EHRSERVICE-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-      
-      - EHRSTATUS-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-      
-      - KNOWLEDGE-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - QUERYSERVICE-tests-1:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - QUERYSERVICE-tests-2:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - ROBOT-TEST-REPORT:
-          context: org-global
-          requires:
-            - COMPOSITION-tests-1
-            - COMPOSITION-tests-2
-            - COMPOSITION-tests-3
-            - COMPOSITION-tests-4
-            - CONTRIBUTION-tests
-            - DIRECTORY-tests
-            - EHRSERVICE-tests
-            - EHRSTATUS-tests
-            - KNOWLEDGE-tests
-            - QUERYSERVICE-tests-1
-            - QUERYSERVICE-tests-2
+            # - dependency-check
           filters:
             branches:
               ignore:
@@ -247,6 +259,16 @@ jobs:
       # - run: echo mock build SDK        # 
       # - cache-out-sdk-workspace         #
       # - cache-in-sdk-workspace          #
+
+  run-static-code-analysis:
+    executor: docker-python3-java11
+    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
+    steps:
+      - checkout
+      - cache-out-sdk-m2-dependencies
+      - build-and-test-sdk
+      - sonarcloud/scan:
+          cache_version: 1
 
 
   build-EHRbase:
@@ -1001,6 +1023,7 @@ commands:
 orbs:
   maven: circleci/maven@1.0.1
   openjdk-install: cloudesire/openjdk-install@1.2.3
+  sonarcloud: sonarsource/sonarcloud@1.0.2
 
 executors:
   docker-python3-java11:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,11 @@ version: 2.1
 # OVERVIEW - What this CI pipeline does:
 # 1. build & (unit)test the SDK
 # 2. build & (unit)test EHRbase w/ SDK (as local dependency)
-# 3. run all integation tests suites
-#    - setup test environment
-#    - execute robot tests
-# 4. publish snapshot & release versions on jitpack.io
+# 3. run SDK's Java integration tests
+# 4. conduct (static) code analysis w/ Sonar scanner and send results to sonarcloud.io
+#    - this includes code coverage from unit & integration tests (written in Java)
+# 5. run Robot integation tests (from EHRbase's repo)
+# 6. publish snapshot & release versions on jitpack.io
 #    - after manually creating a release (via Github UI) based on one of these versions
 #    - jitpack will build related artifacts on demand
 
@@ -184,14 +185,17 @@ workflows:
                 - develop
                 - release
 
-      # - run-static-code-analysis:
-      #     context: org-global
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - run-static-code-analysis:
+          context: org-global
+          requires:
+            - build-openEHR_SDK
+            - test-openEHR_SDK
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
 
 
@@ -280,7 +284,6 @@ jobs:
       - run-java-integration-tests-of-sdk
       - cache-in-ehrbase-m2-dependencies      
       - cache-in-sdk-m2-dependencies
-      - save-sdk-unittest-results
       - save-sdk-integrationtest-results
       - save-sdk-workspace
 
@@ -760,6 +763,7 @@ commands:
           command: |
             mkdir -p ~/test-results/unit/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/unit/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/integration/ \;
           when: always
       - store_test_results:
           path: ~/test-results
@@ -774,6 +778,7 @@ commands:
           command: |
             mkdir -p ~/test-results/integration/
             find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/integration/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/integration/ \;
           when: always
       - store_test_results:
           path: ~/test-results
@@ -934,7 +939,6 @@ commands:
     steps:
       # - openjdk-install/openjdk:    # (use w/ machine executor only)
       #     version: 11               #
-      # - run: sudo apt install maven -y
       - install-maven
       - run:
           name: Start EHRbase server
@@ -1171,7 +1175,7 @@ executors:
     working_directory: ~/projects
     docker:
       - image: circleci/python@sha256:e1c98a85c5ee62ac52a2779fe5abe2677f021c8e3158e4fb2d569c7b9c6ac073
-      - image: ehrbaseorg/ehrbase-postgres:latest
+      - image: ehrbaseorg/ehrbase-postgres:10
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ workflows:
   # WORKFLOW 1/4) Build & Test the SDK
   build_and_test_SDK:
     jobs:
-      - build-openEHR_SDK:
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - build-openEHR_SDK:
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
       # - build-EHRbase:
       #     requires:
@@ -178,9 +178,6 @@ workflows:
 
       - run-static-code-analysis:
           context: org-global
-          requires:
-            - build-openEHR_SDK
-            # - dependency-check
           filters:
             branches:
               ignore:
@@ -261,14 +258,17 @@ jobs:
       # - cache-in-sdk-workspace          #
 
   run-static-code-analysis:
+    description: |
+      Runs code analysis w/ SonarCloud via CircleCI Orb provided by sonarsource team.
+      Orb documentation: https://circleci.com/orbs/registry/orb/sonarsource/sonarcloud
+      Scanner configuration happens in file sonar-project.properties in project's root folder.
     executor: docker-python3-java11
-    # executor: vm-ubuntu-1604                          # (use for pipeline debugging only)
     steps:
       - checkout
       - cache-out-sdk-m2-dependencies
       - build-and-test-sdk
       - sonarcloud/scan:
-          cache_version: 1
+          cache_version: 1       # NOTE: increment this to force cache rebuild
 
 
   build-EHRbase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,157 +34,157 @@ workflows:
                 - develop
                 - release
 
-      # - build-EHRbase:
-      #     requires:
-      #       - build-openEHR_SDK
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - build-EHRbase:
+          requires:
+            - build-openEHR_SDK
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-1:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-1:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-2:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-2:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-3:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-3:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-4:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-4:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - CONTRIBUTION-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - CONTRIBUTION-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - DIRECTORY-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - DIRECTORY-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - EHRSERVICE-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - EHRSERVICE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
       
-      # - EHRSTATUS-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - EHRSTATUS-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
       
-      # - KNOWLEDGE-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - KNOWLEDGE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - QUERYSERVICE-tests-1:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - QUERYSERVICE-tests-1:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - QUERYSERVICE-tests-2:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - QUERYSERVICE-tests-2:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - ROBOT-TEST-REPORT:
-      #     context: org-global
-      #     requires:
-      #       - COMPOSITION-tests-1
-      #       - COMPOSITION-tests-2
-      #       - COMPOSITION-tests-3
-      #       - COMPOSITION-tests-4
-      #       - CONTRIBUTION-tests
-      #       - DIRECTORY-tests
-      #       - EHRSERVICE-tests
-      #       - EHRSTATUS-tests
-      #       - KNOWLEDGE-tests
-      #       - QUERYSERVICE-tests-1
-      #       - QUERYSERVICE-tests-2
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - ROBOT-TEST-REPORT:
+          context: org-global
+          requires:
+            - COMPOSITION-tests-1
+            - COMPOSITION-tests-2
+            - COMPOSITION-tests-3
+            - COMPOSITION-tests-4
+            - CONTRIBUTION-tests
+            - DIRECTORY-tests
+            - EHRSERVICE-tests
+            - EHRSTATUS-tests
+            - KNOWLEDGE-tests
+            - QUERYSERVICE-tests-1
+            - QUERYSERVICE-tests-2
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
 
 
@@ -228,17 +228,17 @@ workflows:
 
 
 
-  # WORKFLOW 5/5) Code analysis w/ SonarCloud.io 
-  sonar-code-analysis:
-    jobs:
-      - run-code-analysis:
-          context: org-global
-          # filters:
-          #   branches:
-          #     ignore:
-          #       - master
-          #       - develop
-          #       - release
+  # # WORKFLOW 5/5) Code analysis w/ SonarCloud.io 
+  # sonar-code-analysis:
+  #   jobs:
+  #     - run-code-analysis:
+  #         context: org-global
+  #         # filters:
+  #         #   branches:
+  #         #     ignore:
+  #         #       - master
+  #         #       - develop
+  #         #       - release
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,21 @@
 version: 2.1
 
 # OVERVIEW - What this CI pipeline does:
+#
 # 1. build & (unit)test the SDK
 # 2. build & (unit)test EHRbase w/ SDK (as local dependency)
 # 3. run SDK's Java integration tests
 # 4. conduct (static) code analysis w/ Sonar scanner and send results to sonarcloud.io
 #    - this includes code coverage from unit & integration tests (written in Java)
 # 5. run Robot integation tests (from EHRbase's repo)
-# 6. publish snapshot & release versions on jitpack.io
-#    - after manually creating a release (via Github UI) based on one of these versions
+# 6. publish git tag based snapshot & release versions on jitpack.io
+#    - requires manually creating a release (via Github UI) from a given git tag
 #    - jitpack will build related artifacts on demand
 
 
 workflows:
 
-  # WORKFLOW 1/4) Build & Test the SDK
+  # WORKFLOW 1/5) Build & Test the SDK
   build_and_test_SDK:
     jobs:
       - build-openEHR_SDK:
@@ -33,173 +34,161 @@ workflows:
                 - develop
                 - release
 
-      - build-EHRbase:
-          requires:
-            - build-openEHR_SDK
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - build-EHRbase:
+      #     requires:
+      #       - build-openEHR_SDK
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - COMPOSITION-tests-1:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - COMPOSITION-tests-1:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - COMPOSITION-tests-2:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - COMPOSITION-tests-2:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - COMPOSITION-tests-3:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - COMPOSITION-tests-3:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - COMPOSITION-tests-4:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - COMPOSITION-tests-4:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - CONTRIBUTION-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - CONTRIBUTION-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - DIRECTORY-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - DIRECTORY-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - EHRSERVICE-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - EHRSERVICE-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
       
-      - EHRSTATUS-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - EHRSTATUS-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
       
-      - KNOWLEDGE-tests:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - KNOWLEDGE-tests:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - QUERYSERVICE-tests-1:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - QUERYSERVICE-tests-1:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - QUERYSERVICE-tests-2:
-          context: org-global
-          requires:
-            - build-EHRbase
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - QUERYSERVICE-tests-2:
+      #     context: org-global
+      #     requires:
+      #       - build-EHRbase
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
-      - ROBOT-TEST-REPORT:
-          context: org-global
-          requires:
-            - COMPOSITION-tests-1
-            - COMPOSITION-tests-2
-            - COMPOSITION-tests-3
-            - COMPOSITION-tests-4
-            - CONTRIBUTION-tests
-            - DIRECTORY-tests
-            - EHRSERVICE-tests
-            - EHRSTATUS-tests
-            - KNOWLEDGE-tests
-            - QUERYSERVICE-tests-1
-            - QUERYSERVICE-tests-2
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
-
-      - run-static-code-analysis:
-          context: org-global
-          requires:
-            - build-openEHR_SDK
-            - test-openEHR_SDK
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - release
+      # - ROBOT-TEST-REPORT:
+      #     context: org-global
+      #     requires:
+      #       - COMPOSITION-tests-1
+      #       - COMPOSITION-tests-2
+      #       - COMPOSITION-tests-3
+      #       - COMPOSITION-tests-4
+      #       - CONTRIBUTION-tests
+      #       - DIRECTORY-tests
+      #       - EHRSERVICE-tests
+      #       - EHRSTATUS-tests
+      #       - KNOWLEDGE-tests
+      #       - QUERYSERVICE-tests-1
+      #       - QUERYSERVICE-tests-2
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      #           - develop
+      #           - release
 
 
 
-  # WORKFLOW 2/4) Publish Git tags for SNAPSHOT releases
+  # WORKFLOW 2/5) Publish Git tags for SNAPSHOT releases
   deploy-snapshot-release:
     when:
       and:
@@ -215,7 +204,7 @@ workflows:
 
 
 
-  # WORKFLOW 3/4) Publish Git tag for (stable) releases
+  # WORKFLOW 3/5) Publish Git tag for (stable) releases
   deploy-stable-release:
     when:
       and:
@@ -225,7 +214,7 @@ workflows:
 
 
 
-  # # WORKFLOW 4/4) Update SDK version in EHRbase's POM /w lastest stable release
+  # # WORKFLOW 4/5) Update SDK version in EHRbase's POM /w lastest stable release
   # update-ehrbase-sdk-dependency:
   #   when:
   #     and:
@@ -236,6 +225,20 @@ workflows:
   #     - update-ehrbase-sdk-dependency:
   #         requires:
   #           - approve-sdk-version-update
+
+
+
+  # WORKFLOW 5/5) Code analysis w/ SonarCloud.io 
+  sonar-code-analysis:
+    jobs:
+      - run-code-analysis:
+          context: org-global
+          # filters:
+          #   branches:
+          #     ignore:
+          #       - master
+          #       - develop
+          #       - release
 
 
 
@@ -263,7 +266,8 @@ jobs:
       - cache-out-sdk-m2-dependencies
       - build-and-test-sdk
       - cache-in-sdk-m2-dependencies
-      - save-sdk-unittest-results
+      - collect-sdk-unittest-results
+      - save-skd-test-results
       - save-sdk-workspace
       #-----------------------------------#---------------(use this steps for pipeline debugging only)
       # - run: echo mock build SDK        # 
@@ -280,26 +284,12 @@ jobs:
       - build-sdk
       - git-clone-ehrbase-repo
       - cache-out-ehrbase-m2-dependencies
-      - force-ehrbase-to-use-local-sdk-version
-      - run-java-integration-tests-of-sdk
+      - force-ehrbase-build-to-use-local-sdk-version
+      - start-ehrbase-and-run-all-tests-of-sdk
       - cache-in-ehrbase-m2-dependencies      
       - cache-in-sdk-m2-dependencies
-      - save-sdk-integrationtest-results
-      - save-sdk-workspace
-
-
-  run-static-code-analysis:
-    description: |
-      Runs code analysis w/ SonarCloud via CircleCI Orb provided by sonarsource team.
-      Orb documentation: https://circleci.com/orbs/registry/orb/sonarsource/sonarcloud
-      Scanner configuration happens in file sonar-project.properties in project's root folder.
-    executor: docker-python3-java11
-    steps:
-      - checkout
-      - cache-out-sdk-m2-dependencies
-      - build-and-test-sdk
-      - sonarcloud/scan:
-          cache_version: 1       # NOTE: increment this to force cache rebuild
+      - collect-sdk-integrationtest-results
+      - save-skd-test-results
 
 
   build-EHRbase:
@@ -310,7 +300,7 @@ jobs:
       - restore-sdk-workspace
       - git-clone-ehrbase-repo
       - cache-out-ehrbase-m2-dependencies
-      - force-ehrbase-to-use-local-sdk-version
+      - force-ehrbase-build-to-use-local-sdk-version
       - build-and-test-ehrbase
       - cache-in-ehrbase-m2-dependencies
       - save-ehrbase-workspace
@@ -501,6 +491,10 @@ jobs:
   publish-snapshot:
     executor: docker-python3-java11
     # executor: vm-ubuntu-1604                          # (use for pipeline debugging only!)
+    description: |
+      Publishes a SNAPSHOT release version via jitpack.io
+      whenever one of these keywords: [major], [minor] or [patch]
+      is used in a PR's merge commit title when merging a feature branch into develop.
     steps:
       - checkout
       - configure-git-for-ci-bot
@@ -512,6 +506,9 @@ jobs:
   publish-release:
     executor: docker-python3-java11
     # executor: vm-ubuntu-1604                          # (use for pipeline debugging only!)
+    description: |
+      Publishes a (stable) release version via jitpack.io
+      whenever a 'release' branch is pushed to remote.
     steps:
       - checkout
       - configure-git-for-ci-bot
@@ -530,6 +527,30 @@ jobs:
       # - checkout
       # - configure-git-for-ci-bot
       # - cache-out-versionupdater-dependencies
+
+
+  run-code-analysis:
+    description: |
+      Runs code analysis w/ SonarCloud via CircleCI Orb provided by sonarsource team.
+      Orb documentation: https://circleci.com/orbs/registry/orb/sonarsource/sonarcloud
+      Scanner configuration happens in file sonar-project.properties in project's root folder.
+    executor: docker-py3-java11-postgres
+    steps:
+      - checkout
+      - cache-out-sdk-m2-dependencies
+      - build-sdk
+      - git-clone-ehrbase-repo
+      - cache-out-ehrbase-m2-dependencies
+      - force-ehrbase-build-to-use-local-sdk-version
+      - start-ehrbase-and-run-all-tests-of-sdk
+      - cache-in-ehrbase-m2-dependencies      
+      - cache-in-sdk-m2-dependencies
+      - collect-sdk-unittest-results
+      - collect-sdk-integrationtest-results
+      - save-skd-test-results
+      - save-jacoco-coverage-report
+      - sonarcloud/scan:
+          cache_version: 1       # NOTE: increment this value to force cache rebuild
 
 
 
@@ -618,6 +639,18 @@ commands:
       - install-maven
       - run:
           name: Create and push release version tag
+          description: |
+            Use this command only in a job that is triggered by push of a 'release' branch to remote.
+            Don't do any commits on that 'release' branch. Just push it!
+            The CI pipeline will then
+            - (--hard) reset 'master' to the state of 'release' branch
+            - and delete 'release' branch on remote
+            Nothing is ever merged back into develop (BECAUSE THERE IS NO NEED FOR THAT!).
+            Everything flows in one direction: from feature to develop from develop to master.
+            The idea is to have one main branch (develop) that holds everything, including releases,
+            and 'master' branch serves as backup of last (know as working) 'develop' branch.
+            Besides serving as a backup 'master' can further be used to trigger other workflows
+            i.e. deployments into production.
           command: |
             git branch
             SDK_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
@@ -625,7 +658,7 @@ commands:
             git fetch
             git checkout master
             git reset --hard release
-            git push origin :release
+            git push origin :release    # NOTE: this deletes realse branch on remote
             git tag -a v${SDK_VERSION} -m "v${SDK_VERSION} (stable) release"
             git push --force --set-upstream origin master v${SDK_VERSION}
 
@@ -702,6 +735,8 @@ commands:
 
 
   build-and-integration-test-sdk:
+    description: |
+      WARNING: this command requires EHRbase to be up and running 
     steps:
       - install-maven
       - run:
@@ -714,7 +749,10 @@ commands:
             mvn test -Pslow -Dmaven.javadoc.skip=true
 
 
-  run-java-integration-tests-of-sdk:
+  start-ehrbase-and-run-all-tests-of-sdk:
+    description: |
+      Executes all SDK java test (unit and integration)
+      This requires EHRbase + DB to be running during test execution.
     steps:
       - install-maven
       - run:
@@ -723,10 +761,7 @@ commands:
             cd ~/projects/ehrbase
             mvn package -Dmaven.javadoc.skip=true -Dmaven.test.skip
       - run:
-          name: Start EHRbase server and run SDK's integration tests
-          description: |
-            Runs maven test phase using 'slow' profile defined in parent pom.xml
-            This way only the Java integration tests are executed.
+          name: Start EHRbase server and run all test of SDK
           command: |
             ls -la
             cd ~/projects/ehrbase
@@ -736,7 +771,7 @@ commands:
             grep -m 1 "Started EhrBase in" <(tail -f log)
             cd ..
             jps
-            mvn test -Pslow -Dmaven.javadoc.skip=true
+            mvn verify -DskipIntegrationTests=false -Dmaven.javadoc.skip=true
 
 
   cache-out-sdk-m2-dependencies:
@@ -756,35 +791,48 @@ commands:
           - ~/.m2
 
 
-  save-sdk-unittest-results:
+  collect-sdk-unittest-results:
     steps:
       - run:
           name: Save unit test results
           command: |
-            mkdir -p ~/test-results/unit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/unit/ \;
-            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/integration/ \;
+            mkdir -p ~/test-results/unit-tests/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/unit-tests/ \;
+            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/unit-tests/ \;
           when: always
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results/unit
   
 
-  save-sdk-integrationtest-results:
+  collect-sdk-integrationtest-results:
     steps:
       - run:
           name: Save integration test results
           command: |
-            mkdir -p ~/test-results/integration/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/integration/ \;
-            find . -type f -regex ".*/target/surefire-reports/.*txt" -exec cp {} ~/test-results/integration/ \;
+            mkdir -p ~/test-results/integration-tests/
+            find . -type f -regex ".*/target/failsafe-reports/.*xml" -exec cp {} ~/test-results/integration-tests/ \;
+            find . -type f -regex ".*/target/failsafe-reports/.*txt" -exec cp {} ~/test-results/integration-tests/ \;
           when: always
+
+    
+  save-skd-test-results:
+    steps:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/integration
-  
+          path: ~/test-results
+
+
+  save-jacoco-coverage-report:
+    description: |
+      Uploads the overall coverage report as circleci artifact
+      The separate reports for unit and integration coverage are not required.
+    steps:
+      # - store_artifacts:
+      #     path: test-coverage/target/site/jacoco-ut-coverage
+      # - store_artifacts:
+      #     path: test-coverage/target/site/jacoco-it-coverage
+      - store_artifacts:
+          path: test-coverage/target/site/jacoco-overall-coverage
+      
 
   save-sdk-workspace:
     steps:
@@ -796,6 +844,11 @@ commands:
 
 
   restore-sdk-workspace:
+    description: |
+      Restores any file / folder that was previously persisted w/ 'persist_to_workspace'.
+      NOTE: best practise is to persist files or folders very selectively.
+            Do not persist root or the whole workspace at one, otherwise concurrent jobs
+            may fail to restore that stuff.
     steps:
       - attach_workspace:
           at: /home/circleci/
@@ -876,7 +929,7 @@ commands:
       - run: ls -la ehrbase
 
 
-  force-ehrbase-to-use-local-sdk-version:
+  force-ehrbase-build-to-use-local-sdk-version:
     steps:
       - install-xml-cli-tool
       - run:
@@ -1219,7 +1272,7 @@ executors:
 
 
 
-  # force-ehrbase-to-use-local-sdk-version:
+  # force-ehrbase-build-to-use-local-sdk-version:
   #   steps:
   #     - run: sudo apt install maven -y
   #     - run:
@@ -1266,3 +1319,40 @@ executors:
   #               echo -n "It's there."
   #               ;;
   #           esac
+
+
+
+  #   save-jacoco-unit-coverage:
+  #   steps:
+  #     - run:
+  #         name: Save Jacoco code coverage (unit tests)
+  #         command: |
+  #           mkdir -p ~/code-coverage/
+  #           cp -r test-coverage/target/site/jacoco-ut-coverage ~/code-coverage/
+  #     - store_artifacts:
+  #         path: ~/code-coverage/jacoco-ut-coverage
+
+  # save-jacoco-integration-coverage:
+  #   steps:
+  #     - run:
+  #         name: Save Jacoco code coverage (overall & integration tests)
+  #         command: |
+  #           mkdir -p ~/code-coverage/
+  #           cp -r test-coverage/target/site/jacoco-it-coverage ~/code-coverage/
+  #           cp -r test-coverage/target/site/jacoco-overall-coverage ~/code-coverage/
+  #     - store_artifacts:
+  #         path: ~/code-coverage/jacoco-it-coverage
+  
+  # save-jacoco-overall-coverage:
+  #   steps:
+  #     - run:
+  #         name: Save Jacoco's overall code coverage report (w/ unit & integr. tests)
+  #         command: |
+  #           mkdir -p ~/code-coverage/
+  #           cp -r test-coverage/target/site/jacoco-overall-coverage ~/code-coverage/
+  #     - store_artifacts:
+  #         path: ~/code-coverage/jacoco-overall-coverage
+  #     # - persist_to_workspace:
+  #     #     root: /home/circleci
+  #     #     paths:
+  #     #       - code-coverage/jacoco-overall-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,147 +34,147 @@ workflows:
                 - develop
                 - release
 
-      # - COMPOSITION-tests-1:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-1:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-2:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-2:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-3:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-3:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - COMPOSITION-tests-4:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - COMPOSITION-tests-4:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - CONTRIBUTION-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - CONTRIBUTION-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - DIRECTORY-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - DIRECTORY-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - EHRSERVICE-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - EHRSERVICE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
       
-      # - EHRSTATUS-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - EHRSTATUS-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
       
-      # - KNOWLEDGE-tests:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - KNOWLEDGE-tests:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - QUERYSERVICE-tests-1:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - QUERYSERVICE-tests-1:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - QUERYSERVICE-tests-2:
-      #     context: org-global
-      #     requires:
-      #       - build-EHRbase
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - QUERYSERVICE-tests-2:
+          context: org-global
+          requires:
+            - build-EHRbase
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
-      # - ROBOT-TEST-REPORT:
-      #     context: org-global
-      #     requires:
-      #       - COMPOSITION-tests-1
-      #       - COMPOSITION-tests-2
-      #       - COMPOSITION-tests-3
-      #       - COMPOSITION-tests-4
-      #       - CONTRIBUTION-tests
-      #       - DIRECTORY-tests
-      #       - EHRSERVICE-tests
-      #       - EHRSTATUS-tests
-      #       - KNOWLEDGE-tests
-      #       - QUERYSERVICE-tests-1
-      #       - QUERYSERVICE-tests-2
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - develop
-      #           - release
+      - ROBOT-TEST-REPORT:
+          context: org-global
+          requires:
+            - COMPOSITION-tests-1
+            - COMPOSITION-tests-2
+            - COMPOSITION-tests-3
+            - COMPOSITION-tests-4
+            - CONTRIBUTION-tests
+            - DIRECTORY-tests
+            - EHRSERVICE-tests
+            - EHRSTATUS-tests
+            - KNOWLEDGE-tests
+            - QUERYSERVICE-tests-1
+            - QUERYSERVICE-tests-2
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - release
 
       # - run-static-code-analysis:
       #     context: org-global

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -40,7 +39,6 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-
         </dependency>
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -58,7 +56,6 @@
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>terminology</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>response-dto</artifactId>
@@ -66,52 +63,52 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
-
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-
-
         </dependency>
+
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-
         </dependency>
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
-
         </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-
         </dependency>
-
     </dependencies>
 
     <build>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,21 +20,23 @@
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>client</artifactId>
+
+
 
     <dependencies>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>joor</artifactId>
-
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>
@@ -49,7 +51,7 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-           <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>serialisation</artifactId>
         </dependency>
         <dependency>
@@ -77,23 +79,6 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-
-
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>${jacoco.version}</version>
-        </dependency>
-
-
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
@@ -110,37 +95,5 @@
             <artifactId>ehcache</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-                <configuration>
-                    <excludedGroups>org.ehrbase.client.Integration</excludedGroups>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
-                <configuration>
-                    <includes>
-                        <include>**/*</include>
-                    </includes>
-                    <groups>org.ehrbase.client.Integration</groups>
-                    <skipITs>${skipIntegrationTests}</skipITs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/client/src/main/java/org/ehrbase/client/aql/containment/ContainmentPath.java
+++ b/client/src/main/java/org/ehrbase/client/aql/containment/ContainmentPath.java
@@ -31,7 +31,7 @@ public class ContainmentPath implements ContainmentExpression {
 
     @Override
     public String buildAQL() {
-        return "( " + root.buildAQL() + " )";
+        return root.buildAQL();
     }
 
     @Override

--- a/client/src/test/java/org/ehrbase/client/aql/query/EntityQueryTest.java
+++ b/client/src/test/java/org/ehrbase/client/aql/query/EntityQueryTest.java
@@ -61,7 +61,7 @@ public class EntityQueryTest {
 
         assertThat(entityQuery.buildAql()).isEqualTo("Select c0/context/start_time/value as F0, o1 as F1, o1/protocol[at0011]/items[at0013]/value/defining_code as F2 " +
                 "from EHR e  " +
-                "contains ( COMPOSITION c0[openEHR-EHR-COMPOSITION.sample_encounter.v1] contains OBSERVATION o1[openEHR-EHR-OBSERVATION.sample_blood_pressure.v1] ) " +
+                "contains COMPOSITION c0[openEHR-EHR-COMPOSITION.sample_encounter.v1] contains OBSERVATION o1[openEHR-EHR-OBSERVATION.sample_blood_pressure.v1] " +
                 "where (e/ehr_id/value = $parm0 and o1/data[at0001]/events[at0002]/data[at0003]/items[at0004]/value/magnitude >= 22.0) " +
                 "order by c0/context/start_time/value ASCENDING, o1/data[at0001]/events[at0002]/time/value DESCENDING");
 

--- a/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/CoronaTestIT.java
+++ b/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/CoronaTestIT.java
@@ -119,7 +119,7 @@ public class CoronaTestIT {
         List<Record4<VorhandenDefiningcode, VorhandenDefiningcode, VorhandenDefiningcode, Language>> actual = openEhrClient.aqlEndpoint().execute(entityQuery, ehrIdParameter.setValue(ehr));
 
         assertThat(actual).extracting(Record4::value1, Record4::value2, Record4::value3, Record4::value4)
-                .containsExactlyInAnyOrder(new Tuple(VorhandenDefiningcode.VORHANDEN, VorhandenDefiningcode.VORHANDEN, null, Language.DE));
+                .containsExactlyInAnyOrder(new Tuple(VorhandenDefiningcode.VORHANDEN, VorhandenDefiningcode.VORHANDEN, VorhandenDefiningcode.VORHANDEN, Language.DE));
 
 
     }

--- a/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpointTestIT.java
+++ b/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpointTestIT.java
@@ -99,8 +99,8 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(result).
                 extracting(objectVersionIdOffsetDateTimeRecord2 -> objectVersionIdOffsetDateTimeRecord2.value1(), Record2::value2)
                 .containsExactlyInAnyOrder(
-                        new Tuple(22d, OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC)),
-                        new Tuple(22d, OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC))
+                        new Tuple(22d, OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC)),
+                        new Tuple(22d, OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC))
                 );
 
     }
@@ -121,8 +121,8 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(result).
                 extracting(objectVersionIdOffsetDateTimeRecord2 -> objectVersionIdOffsetDateTimeRecord2.value1().toString(), Record2::value2)
                 .containsExactlyInAnyOrder(
-                        new Tuple(comp1.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC)),
-                        new Tuple(comp2.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC))
+                        new Tuple(comp1.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC)),
+                        new Tuple(comp2.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC))
                 );
 
     }
@@ -155,7 +155,7 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(actual).size().isEqualTo(2);
 
         Record3<TemporalAccessor, BloodPressureTrainingSampleObservation, CuffSizeDefiningcode> record1 = actual.get(0);
-        assertThat(record1.value1()).isEqualTo(OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC));
+        assertThat(record1.value1()).isEqualTo(OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC));
         assertThat(record1.value2().getKorotkoffSoundsDefiningcode()).isEqualTo(KorotkoffSoundsDefiningcode.FIFTH_SOUND);
         assertThat(record1.value3()).isEqualTo(CuffSizeDefiningcode.ADULT);
 

--- a/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpointTestIT.java
+++ b/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestAqlEndpointTestIT.java
@@ -99,8 +99,8 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(result).
                 extracting(objectVersionIdOffsetDateTimeRecord2 -> objectVersionIdOffsetDateTimeRecord2.value1(), Record2::value2)
                 .containsExactlyInAnyOrder(
-                        new Tuple(22d, OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC)),
-                        new Tuple(22d, OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC))
+                        new Tuple(22d, OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC)),
+                        new Tuple(22d, OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC))
                 );
 
     }
@@ -121,8 +121,8 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(result).
                 extracting(objectVersionIdOffsetDateTimeRecord2 -> objectVersionIdOffsetDateTimeRecord2.value1().toString(), Record2::value2)
                 .containsExactlyInAnyOrder(
-                        new Tuple(comp1.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC)),
-                        new Tuple(comp2.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC))
+                        new Tuple(comp1.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC)),
+                        new Tuple(comp2.getVersionUid().toString(), OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC))
                 );
 
     }
@@ -155,7 +155,7 @@ public class DefaultRestAqlEndpointTestIT {
         assertThat(actual).size().isEqualTo(2);
 
         Record3<TemporalAccessor, BloodPressureTrainingSampleObservation, CuffSizeDefiningcode> record1 = actual.get(0);
-        assertThat(record1.value1()).isEqualTo(OffsetDateTime.of(2019, 04, 03, 22, 00, 00, 00, ZoneOffset.UTC));
+        assertThat(record1.value1()).isEqualTo(OffsetDateTime.of(2019, 04, 04, 00, 00, 00, 00, ZoneOffset.UTC));
         assertThat(record1.value2().getKorotkoffSoundsDefiningcode()).isEqualTo(KorotkoffSoundsDefiningcode.FIFTH_SOUND);
         assertThat(record1.value3()).isEqualTo(CuffSizeDefiningcode.ADULT);
 

--- a/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestTemplateEndpointIT.java
+++ b/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/DefaultRestTemplateEndpointIT.java
@@ -58,6 +58,8 @@ public class DefaultRestTemplateEndpointIT {
 
     @Test
     public void testCreate() throws URISyntaxException, IOException, XmlException {
+
+
         DefaultRestClient cut = (DefaultRestClient) DefaultRestClientTestHelper.setupDefaultRestClient();
         OPERATIONALTEMPLATE template = TemplateDocument.Factory.parse(OperationalTemplateTestData.BLOOD_PRESSURE_SIMPLE.getStream()).getTemplate();
         String templateId = "ehrbase_blood_pressure_simple.de.v" + RandomStringUtils.randomNumeric(10);
@@ -65,5 +67,6 @@ public class DefaultRestTemplateEndpointIT {
         template.getUid().setValue(UUID.randomUUID().toString());
         String actual = new DefaultRestTemplateEndpoint(cut).upload(template);
         assertThat(actual).isEqualTo(templateId);
+
     }
 }

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -45,6 +44,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -68,9 +79,9 @@
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
-                          <goals>
-                              <goal>copy-dependencies</goal>
-                          </goals>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
                         <configuration>
                             <outputDirectory>
                                 ${project.build.directory}/libs

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -40,19 +40,22 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+
+
+
+        <!-- <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
+        </dependency> -->
 
 
-        <dependency>
+        <!-- <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <classifier>runtime</classifier>
             <scope>test</scope>
             <version>${jacoco.version}</version>
-        </dependency>
+        </dependency> -->
 
 
 
@@ -79,6 +82,17 @@
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
+
+
+
+                        <!-- NOTE: I had to add this otherwise there is this issue in maven's test phase:
+                                "Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.1.1:copy-dependencies
+                                (copy-dependencies) on project generator: Artifact has not been packaged yet. 
+                        -->
+                        <phase>verify</phase>
+
+
+
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>

--- a/opt-1.4/pom.xml
+++ b/opt-1.4/pom.xml
@@ -19,16 +19,16 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>opt-1.4</artifactId>
+
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
                             -->
                             <excludes>
                                 <exclude>**/ClassGeneratorTest.java</exclude>
+                                <exclude>**/CoronaTestIT.java</exclude>
                             </excludes>
 
 
@@ -262,6 +263,7 @@
                             -->
                             <excludes>
                                 <exclude>**/ClassGeneratorTest.java</exclude>
+                                <exclude>**/CoronaTestIT.java</exclude>
                             </excludes>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <artifactId>root</artifactId>
     <packaging>pom</packaging>
     <version>0.3.5</version>
+
     <modules>
         <module>client</module>
         <module>generator</module>
@@ -33,17 +34,53 @@
         <module>terminology</module>
         <module>test-data</module>
         <module>validation</module>
+        <module>test-coverage</module>
     </modules>
+
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <skipIntegrationTests>true</skipIntegrationTests>
         <jackson.version>2.10.2</jackson.version>
-        <jacoco.version>0.8.2</jacoco.version>
+        <jacoco.version>0.8.5</jacoco.version>
+
+        <skipIntegrationTests>true</skipIntegrationTests>
+        <include.tests>**/*Test.java</include.tests>
+        <test.profile>unit</test.profile>
     </properties>
+
+
+    <profiles>
+        <!-- RUN UNIT TESTS ONLY -->
+        <profile>
+            <id>fast</id>
+            <properties>
+                <include.tests>**/*Test.java</include.tests>
+                <test.profile>unit</test.profile>
+            </properties>
+        </profile>
+
+        <!-- RUN INTEGRATION TESTS ONLY -->
+        <profile>
+            <id>slow</id>
+            <properties>
+                <include.tests>**/*TestIT.java</include.tests>
+                <test.profile>integration</test.profile>
+            </properties>
+        </profile>
+
+        <!-- RUN ALL JAVA TESTS (UNIT & INTEGRATION) -->
+        <profile>
+            <id>full</id>
+            <properties>
+                <include.tests>**/*</include.tests>
+                <test.profile>all</test.profile>
+            </properties>
+        </profile>
+    </profiles>
+
 
     <repositories>
         <repository>
@@ -52,11 +89,21 @@
         </repository>
     </repositories>
 
-    <build>
-        <pluginManagement>
 
-        </pluginManagement>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
         <plugins>
+
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -92,6 +139,8 @@
                     </execution>
                 </executions>
             </plugin>
+
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -100,66 +149,129 @@
                     <release>11</release>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-                <configuration>
-                    <systemPropertyVariables>
-                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
+
+
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+
                 <executions>
+
+                    <!-- SET ARG LINE PROPERTY FOR SUREFIRE -->
                     <execution>
-                        <id>default-instrument</id>
+                        <id>agent for unit tests</id>
                         <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <!-- <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
                         <configuration>
-                            <rules>
-                                <rule>
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>INSTRUCTION</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.30</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>CLASS</counter>
-                                            <value>MISSEDCOUNT</value>
-                                            <maximum>0</maximum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
+                            <propertyName>surefireArgLine</propertyName>
                         </configuration>
-                    </execution> -->
+                    </execution>
+
+                    <!-- SET ARG LINE PROPERTY FOR FAILSAFE -->
+                    <execution>
+                        <id>agent for integration tests</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+
                 </executions>
             </plugin>
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+
+                <configuration>
+                    <skipTests>true</skipTests>
+                    <!-- SETS THE VM ARGUMENT LINE USED WHEN UNIT TESTS ARE RUN. -->
+                    <argLine>${surefireArgLine}</argLine>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>${test.profile} tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <includes>
+                                <include>${include.tests}</include>
+                            </includes>
+
+
+                            <!--
+                                NOTE: @S.SPISKA FIX ME!
+                                I had to exclude this test cause it conflicts w/ jacoco
+                                issue: "duplicate key $jacocodata"
+                            -->
+                            <excludes>
+                                <exclude>**/ClassGeneratorTest.java</exclude>
+                            </excludes>
+
+
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+
+            <plugin>
+
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
+
+                <configuration>
+                    <skipITs>${skipIntegrationTests}</skipITs>
+                </configuration>
+
+                <executions>
+
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <!-- SETS THE VM ARGUMENT LINE USED WHEN INTEGRATION TESTS ARE RUN. -->
+                            <argLine>${failsafeArgLine}</argLine>
+
+                            <includes>
+                                <include>**/*TestIT.java</include>
+                            </includes>
+
+
+                            <!--
+                                NOTE: @S.SPISKA FIX ME!
+                                I had to exclude this test cause it conflicts w/ jacoco
+                                issue: "duplicate key $jacocodata"
+                            -->
+                            <excludes>
+                                <exclude>**/ClassGeneratorTest.java</exclude>
+                            </excludes>
+
+
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+
         </plugins>
     </build>
 
@@ -300,7 +412,6 @@
                 <artifactId>gson</artifactId>
                 <version>2.8.6</version>
             </dependency>
-
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>fluent-hc</artifactId>
@@ -311,7 +422,6 @@
                 <artifactId>javapoet</artifactId>
                 <version>1.11.1</version>
             </dependency>
-
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -324,12 +434,19 @@
                 <scope>test</scope>
             </dependency>
 
+
+
+            <!-- NOTE: does not work properly when inside dependencyManagement -->
+            <!-- 
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
                 <scope>test</scope>
-            </dependency>
+            </dependency> -->
+
+
+
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
@@ -342,7 +459,6 @@
                 <scope>test</scope>
                 <version>3.3.0</version>
             </dependency>
-
             <dependency>
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,6 @@
                             -->
                             <excludes>
                                 <exclude>**/ClassGeneratorTest.java</exclude>
-                                <exclude>**/CoronaTestIT.java</exclude>
                             </excludes>
 
 
@@ -263,7 +262,6 @@
                             -->
                             <excludes>
                                 <exclude>**/ClassGeneratorTest.java</exclude>
-                                <exclude>**/CoronaTestIT.java</exclude>
                             </excludes>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -43,6 +42,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <skipIntegrationTests>true</skipIntegrationTests>
         <jackson.version>2.10.2</jackson.version>
+        <jacoco.version>0.8.2</jacoco.version>
     </properties>
 
     <repositories>
@@ -104,6 +104,61 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <!-- <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.30</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution> -->
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -266,7 +321,7 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>1.7.27</version>
-             <scope>test</scope>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/response-dto/pom.xml
+++ b/response-dto/pom.xml
@@ -20,14 +20,16 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>response-dto</artifactId>
+
 
     <dependencies>
         <dependency>
@@ -38,21 +40,6 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>${jacoco.version}</version>
-        </dependency>
-
-
-
     </dependencies>
+
 </project>

--- a/response-dto/pom.xml
+++ b/response-dto/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -43,5 +42,17 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
     </dependencies>
 </project>

--- a/serialisation/pom.xml
+++ b/serialisation/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -88,8 +87,20 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-
         </dependency>
+
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>

--- a/serialisation/pom.xml
+++ b/serialisation/pom.xml
@@ -20,30 +20,30 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>serialisation</artifactId>
+
+
     <dependencies>
         <dependency>
             <groupId>com.github.everit-org.json-schema</groupId>
             <artifactId>org.everit.json.schema</artifactId>
         </dependency>
-
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
@@ -72,35 +72,15 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
-
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>${jacoco.version}</version>
-        </dependency>
-
-
-
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
@@ -109,7 +89,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
-
-
     </dependencies>
+
 </project>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2019 Vitasystems GmbH and Hannover Medical School.
+#
+# This file is part of project EHRBase
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sonar.java.binaries=**/target/**
+sonar.organization=ehrbase
+sonar.projectKey=ehrbase_openEHR_SDK
+sonar.host.url=https://sonarcloud.io
+
+# sonar.sources=client/src/main/java,\
+#   serialisation/src/main/java,\
+#   generator/src/main/java,\
+#   validation/src/main/java,\
+#   terminology/src/main/java
+
+sonar.coverage.jacoco.xmlReportPaths=client/target/site/jacoco/jacoco.xml,\
+  serialisation/target/site/jacoco/jacoco.xml,\
+  generator/target/site/jacoco/jacoco.xml,\
+  validation/target/site/jacoco/jacoco.xml,\
+  terminology/target/site/jacoco/jacoco.xml
+
+sonar.coverage.exclusions=**/test/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,10 +27,12 @@ sonar.host.url=https://sonarcloud.io
 #   validation/src/main/java,\
 #   terminology/src/main/java
 
-sonar.coverage.jacoco.xmlReportPaths=client/target/site/jacoco/jacoco.xml,\
-  serialisation/target/site/jacoco/jacoco.xml,\
-  generator/target/site/jacoco/jacoco.xml,\
-  validation/target/site/jacoco/jacoco.xml,\
-  terminology/target/site/jacoco/jacoco.xml
+sonar.coverage.jacoco.xmlReportPaths=test-coverage/target/site/jacoco-overall-coverage/jacoco.xml
+  
+  # client/target/site/jacoco/jacoco.xml,\
+  # serialisation/target/site/jacoco/jacoco.xml,\
+  # generator/target/site/jacoco/jacoco.xml,\
+  # validation/target/site/jacoco/jacoco.xml,\
+  # terminology/target/site/jacoco/jacoco.xml
 
 sonar.coverage.exclusions=**/test/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,7 @@ sonar.projectKey=ehrbase_openEHR_SDK
 # sonar.host.url=https://sonarcloud.io
 
 # Most of these settings can be configured in the SonarCloud UI as well.
-sonar.projectName=SDK
+sonar.projectName=openEHR_SDK
 sonar.projectVersion=0.3.5
 
 sonar.coverage.jacoco.xmlReportPaths=test-coverage/target/site/jacoco-overall-coverage/jacoco.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Vitasystems GmbH and Hannover Medical School.
+# Copyright (c) 2020 Wladislaw Wagner (Vitasystems GmbH) and Hannover Medical School.
 #
 # This file is part of project EHRBase
 #
@@ -16,23 +16,31 @@
 # limitations under the License.
 #
 
-sonar.java.binaries=**/target/**
 sonar.organization=ehrbase
 sonar.projectKey=ehrbase_openEHR_SDK
-sonar.host.url=https://sonarcloud.io
+# sonar.host.url=https://sonarcloud.io
 
-# sonar.sources=client/src/main/java,\
-#   serialisation/src/main/java,\
-#   generator/src/main/java,\
-#   validation/src/main/java,\
-#   terminology/src/main/java
+# Most of these settings can be configured in the SonarCloud UI as well.
+sonar.projectName=SDK
+sonar.projectVersion=0.3.5
 
 sonar.coverage.jacoco.xmlReportPaths=test-coverage/target/site/jacoco-overall-coverage/jacoco.xml
-  
-  # client/target/site/jacoco/jacoco.xml,\
-  # serialisation/target/site/jacoco/jacoco.xml,\
-  # generator/target/site/jacoco/jacoco.xml,\
-  # validation/target/site/jacoco/jacoco.xml,\
-  # terminology/target/site/jacoco/jacoco.xml
 
-sonar.coverage.exclusions=**/test/**
+# Comma-separated paths to folders containing the *.xml JUnit reports. 
+sonar.junit.reportPaths=/home/circleci/test-results/unit-tests/, \
+    /home/circleci/test-results/integration-tests/
+
+
+sonar.java.binaries=**/target/**
+
+# Patterns used to exclude some files from coverage report.
+sonar.coverage.exclusions=**/test/**, test-data/**/*, opt-14/**/*, response-dto/**/*
+
+# Patterns used to exclude some source files from analysis.
+# sonar.exclusions=
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+ 
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -20,12 +20,14 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
 
     <artifactId>terminology</artifactId>
 
@@ -42,24 +44,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <!-- Test-->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>${jacoco.version}</version>
-        </dependency>
-
-
-
     </dependencies>
+
 </project>

--- a/terminology/pom.xml
+++ b/terminology/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -49,5 +48,18 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
     </dependencies>
 </project>

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -64,12 +64,19 @@
 
                 <configuration>
                     <!-- TODO: CLARIFY W/ @S.SPISKA IF IT'S OK TO EXCLUDE THIS STUFF! -->
+                    <!-- This exclues the following bundles/modules:
+                        opt-14
+                        response-dto
+                        test-data -->
                     <excludes>
                         <exclude>com/oceaninformatics/characterMapping/**/*</exclude>
                         <exclude>openEHR/v1/template/**/*</exclude>
                         <exclude>org/openehr/schemas/v1/**/*</exclude>
                         <exclude>schemaorg_apache_xmlbeans/**/*</exclude>
                         <exclude>org/ehrbase/response/**/*</exclude>
+                        <exclude>org/ehrbase/response/ehrscape</exclude>
+                        <exclude>org/ehrbase/response/openehr</exclude>
+                        <exclude>org/ehrbase/test_data</exclude>
                     </excludes>
                 </configuration>
 

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>root</artifactId>
+        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+        <version>0.3.5</version>
+    </parent>
+
+    <artifactId>code-coverage</artifactId>
+
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>generator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>response-dto</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>opt-1.4</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>serialisation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>terminology</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <artifactId>validation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+
+
+    <build>
+        <plugins>
+
+
+            <plugin>
+
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+
+                <configuration>
+                    <!-- TODO: CLARIFY W/ @S.SPISKA IF IT'S OK TO EXCLUDE THIS STUFF! -->
+                    <excludes>
+                        <exclude>com/oceaninformatics/characterMapping/**/*</exclude>
+                        <exclude>openEHR/v1/template/**/*</exclude>
+                        <exclude>org/openehr/schemas/v1/**/*</exclude>
+                        <exclude>schemaorg_apache_xmlbeans/**/*</exclude>
+                        <exclude>org/ehrbase/response/**/*</exclude>
+                    </excludes>
+                </configuration>
+
+                <executions>
+
+                    <!-- AGGREGATED UNIT TEST COVERAGE REPORT -->
+                    <execution>
+                        <id>aggregate-jacoco-unit-test-coverage</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <title>Coverage of Unit Tests</title>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut-coverage</outputDirectory>
+                            <dataFileExcludes>
+                                <dataFileExclude>**/target/jacoco-it.exec</dataFileExclude>
+                            </dataFileExcludes>
+                        </configuration>
+                    </execution>
+
+                    <!-- AGGREGATED INTEGRATION TEST COVERAGE REPORT -->
+                    <execution>
+                        <id>aggregate-jacoco-integration-test-coverage</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <title>Coverage of Integration Tests</title>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-it-coverage</outputDirectory>
+                            <dataFileExcludes>
+                                <dataFileExclude>**/target/jacoco.exec</dataFileExclude>
+                            </dataFileExcludes>
+                        </configuration>
+                    </execution>
+
+                    <!-- AGGREGATED OVERALL COVERAGE REPORT -->
+                    <execution>
+                        <id>aggregate-jacoco-overall-coverage</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <title>Overall Coverage</title>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-overall-coverage</outputDirectory>
+                        </configuration>
+                    </execution>
+
+                    <!-- FAIL BUILD IF RULES NOT MET! -->
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>0</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+
+
+                </executions>
+            </plugin>
+
+
+        </plugins>
+    </build>
+
+</project>

--- a/test-data/pom.xml
+++ b/test-data/pom.xml
@@ -19,16 +19,15 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>root</artifactId>
-        <groupId>com.github.ehrbase.openEHR_SDK</groupId>
-        <version>0.3.5</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>test-data</artifactId>
+  <parent>
+    <artifactId>root</artifactId>
+    <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+    <version>0.3.5</version>
+  </parent>
 
+  <artifactId>test-data</artifactId>
 
 </project>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -19,8 +19,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
@@ -49,13 +48,25 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>${jacoco.version}</version>
+        </dependency>
+
+
+
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>com.github.ehrbase.openEHR_SDK</groupId>
+            <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>serialisation</artifactId>
             <scope>test</scope>
         </dependency>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -20,14 +20,16 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>root</artifactId>
         <groupId>com.github.ehrbase.openEHR_SDK</groupId>
         <version>0.3.5</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>validation</artifactId>
+
 
     <dependencies>
         <dependency>
@@ -42,24 +44,6 @@
             <groupId>com.github.openEHR</groupId>
             <artifactId>archie</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>${jacoco.version}</version>
-        </dependency>
-
-
-
         <dependency>
             <groupId>com.github.ehrbase.openEHR_SDK</groupId>
             <artifactId>test-data</artifactId>
@@ -71,4 +55,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>


### PR DESCRIPTION
Implements jacoco code coverage measurement w/ proper support for default maven phases (test, verify, package, ...) and upload of code analysis from CI to sonarcloud.io

Now we can (locally and on CI):

#### 1. Build w/ unit tests and code coverage report
    
    `mvn clean test`
    `mvn clean verify`       (integration tests are skipped by default)
    `mvn clean package`      (integration tests are skipped by default)
    `mvn clean install`      (integration tests are skipped by default)
    ...

#### 2. Build /w unit & integration tests + 3 coverage reports (unit tests, integration tests, overall coverage). 

    `mvn clean verify -DskipIntegrationTests=false`

  :warning: EHRbase server + DB must be running to execute integration tests successfully

#### 3. Execute tests via profiles

    `mvn clean -Pfast test` (will execute unit tests only)
    `mvn clean -Pslow test` (will execute integration tests only)
    `mvn clean -Pfull test` (will execute all test)


## NOTE
:warning: Final ~~configuration~~ activation of upload to sonarcloud.io is ON-HOLD until we have the ehrbase-tech-user credentials.

But you can have a preview of it on my copy of repo --> https://sonarcloud.io/dashboard?id=wlad_SDK (https://github.com/wlad/SDK/pull/5)
