### PR TITLE
Upgrade to Junit5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ __pycache__
 log.html
 output.xml
 report.html
+
+# VSCode Editor
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,20 @@
 
 
     <dependencies>
+
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Replaces junit(4) dependency w/ org.junit.vintage
- This allows to execute Junit4 tests w/ Junit5.
- Thus old tests can remain untouched while new tests can be written in Junit5 style (therefore also added org.junit.jupiter (Junit5) dependency)