### PR TITLE
Skip sonar analysis on short living release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,12 +233,12 @@ workflows:
     jobs:
       - run-code-analysis:
           context: org-global
-          # filters:
-          #   branches:
-          #     ignore:
-          #       - master
-          #       - develop
-          #       - release
+          filters:
+            branches:
+              ignore:
+                # - master
+                # - develop
+                - release
 
 
 


### PR DESCRIPTION
The release branch is a short living one, it gets deleted automatically after merge thus sonar analysis triggered on release branch fails. Adding it to branches ignore filter in CI config should fix this.