### PR TITLE
Update openEHR_SDK CI pipeline - removes `git --hard reset`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,10 +657,13 @@ commands:
             echo $SDK_VERSION
             git fetch
             git checkout master
-            git reset --hard release
-            git push origin :release    # NOTE: this deletes realse branch on remote
+            git merge release --no-ff -m "NEW RELEASE VERSION: v${SDK_VERSION} [skip ci]"
+            git push origin --delete release    # NOTE: this deletes realse branch on remote
             git tag -a v${SDK_VERSION} -m "v${SDK_VERSION} (stable) release"
-            git push --force --set-upstream origin master v${SDK_VERSION}
+            git push --set-upstream origin master v${SDK_VERSION}
+            git checkout develop
+            git merge master
+            git push --set-upstream origin develop v${SDK_VERSION}
 
 
   configure-git-for-ci-bot:


### PR DESCRIPTION
Applied changes suggested by @StefanWinterfeldtVitasystems  as commended in https://github.com/ehrbase/openEHR_SDK/pull/49#pullrequestreview-479670353

- (short living) release branch is merged into master
- release branch is when deleted from remote
- master is merged back into develop
- result: master and develop are in sync
- git history states clearly: NEW RELEASE VERSION ...

@StefanWinterfeldtVitasystems I've thoroughly tested this change in a playground repo, feel free to check it's [commit history](https://github.com/testautomation/ci-playground-openehr-sdk/commits/develop).

closes https://github.com/ehrbase/project_management/issues/292