### PR TITLE
Feature/428 ci synced feature check workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2.1
 
 # OVERVIEW - What this CI pipeline does:
-# - QUALITY GATE I for fast feedback
-# - QUALITY GATE II for indepth test and analysis
-#
 # 1. build & test the SDK
 # 2. build & test EHRbase w/ SDK (as local dependency)
 # 3. conduct (static) code analysis w/ Sonar scanner and send results to sonarcloud.io
@@ -13,10 +10,27 @@ version: 2.1
 #    - requires manually creating a release (via Github UI) from a given git tag
 #    - jitpack will build related artifacts on demand
 
+# QUALITY GATE I for fast feedback
+# - builds and tests SDK as fast as possible for fast feedback
+# - ehrbase build w/o any tests (mvn even doesn't compile any test code)
+# - no Jacoco code instrumentation
+# - no code coverage metrics and related storage/upload of artifacts
+# - no Java Doc generation
+# - needs less than 50% of time before Robot integration test can start than would be the case in Quality Gate 2
+
+# QUALITY GATE II for indepth test and analysis
+# - Jacoco code instrumentation enabled to get coverage metrics
+# - ehrbase builds with tests enabled
+# - Java docs generation enabled
+# - Sonar code analysis enabled and results uploaded to sonarcloud.io
+# - TODO: enable scheduled execution(?)
+# - TODO: add security test suite(?)
+
+
 
 workflows:
 
-  # WORKFLOW 1/5) Build & Test the SDK
+  # WORKFLOW 1/6) Build & Test the SDK
   QUALITY-GATE-I:
     jobs:
       - build-and-test-openEHR_SDK:
@@ -171,7 +185,7 @@ workflows:
 
 
 
-  # WORKFLOW 2/5) Publish Git tags for SNAPSHOT releases
+  # WORKFLOW 2/6) Publish Git tags for SNAPSHOT releases
   deploy-snapshot-release:
     when:
       and:
@@ -187,7 +201,7 @@ workflows:
 
 
 
-  # WORKFLOW 3/5) Publish Git tag for (stable) releases
+  # WORKFLOW 3/6) Publish Git tag for (stable) releases
   deploy-stable-release:
     when:
       and:
@@ -211,7 +225,7 @@ workflows:
 
 
 
-  # WORKFLOW 5/5) Code analysis w/ SonarCloud.io 
+  # WORKFLOW 5/6) Code analysis w/ SonarCloud.io 
   QUALITY-GATE-II:
     jobs:
       - build-test-and-analyse-openEHR_SDK:
@@ -224,6 +238,19 @@ workflows:
                 - release
 
 
+  # WORKFLOW 6/6) 
+  synced-feature-check:
+      description: |
+        WHAT THIS WORKFLOW DOES
+        =======================
+    jobs:
+      - build-and-test-openEHR_SDK:
+          context: org-global
+          filters:
+            branches:
+              only:
+                - /^sync\/.*/
+                - /^feature\/sync\/.*/
 
 
 
@@ -248,6 +275,28 @@ jobs:
       - cache-out-sdk-m2-dependencies
       - build-sdk
       - git-clone-ehrbase-repo
+      - cache-out-ehrbase-m2-dependencies
+      - force-ehrbase-build-to-use-local-sdk-version
+      - build-and-run-ehrbase-then-run-all-sdk-java-tests
+      - cache-in-ehrbase-m2-dependencies      
+      - cache-in-sdk-m2-dependencies
+      - collect-sdk-unittest-results
+      - collect-sdk-integrationtest-results
+      - save-skd-test-results
+      - save-sdk-workspace
+
+
+  build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK:
+    description: |
+      Build and run all openEHR_SDK Java tests (unit and integration tests)
+      w/ EHRbase being checked out from a sync/*-branch or feature/sync/*-branch 
+    executor: docker-py3-java11-postgres
+    steps:
+      - checkout
+      - cache-out-sdk-m2-dependencies
+      - build-sdk
+      - git-clone-ehrbase-repo
+          branch: ${CIRCLE_BRANCH}
       - cache-out-ehrbase-m2-dependencies
       - force-ehrbase-build-to-use-local-sdk-version
       - build-and-run-ehrbase-then-run-all-sdk-java-tests
@@ -890,12 +939,19 @@ commands:
   # ///////////////////////////////////////////////////////////////////////////
 
   git-clone-ehrbase-repo:
+    parameters:
+      branch:
+        description: Git branch to checkout
+        type: string
+        default: develop
     steps:
       - run:
           name: Git clone EHRbase repo
           command: |
             git clone git@github.com:ehrbase/ehrbase.git
             ls -la
+            cd ehrbase
+            git checkout << parameters.brach >>
   
 
   build-and-test-ehrbase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - COMPOSITION-tests-1:
           context: org-global
@@ -51,6 +53,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - COMPOSITION-tests-2:
           context: org-global
@@ -62,6 +66,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - COMPOSITION-tests-3:
           context: org-global
@@ -73,6 +79,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - COMPOSITION-tests-4:
           context: org-global
@@ -84,6 +92,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - CONTRIBUTION-tests:
           context: org-global
@@ -95,6 +105,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - DIRECTORY-tests:
           context: org-global
@@ -106,6 +118,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - EHRSERVICE-tests:
           context: org-global
@@ -117,6 +131,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
       
       - EHRSTATUS-tests:
           context: org-global
@@ -128,6 +144,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
       
       - KNOWLEDGE-tests:
           context: org-global
@@ -139,6 +157,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - QUERYSERVICE-tests-1:
           context: org-global
@@ -150,6 +170,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - QUERYSERVICE-tests-2:
           context: org-global
@@ -161,6 +183,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
       - ROBOT-TEST-REPORT:
           context: org-global
@@ -182,6 +206,8 @@ workflows:
                 - master
                 - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
 
 
@@ -236,21 +262,156 @@ workflows:
                 - master
                 # - develop
                 - release
+                - /sync\/.*/
+                - /feature/sync\/.*/
 
 
   # WORKFLOW 6/6) 
   synced-feature-check:
-      description: |
-        WHAT THIS WORKFLOW DOES
-        =======================
+    description: |
+      WHAT THIS WORKFLOW DOES
+      =======================
+
+      Build and run all openEHR_SDK Java tests (unit and integration tests)
+      with EHRbase being checked out from a branch named sync/* or sync/feature/*
+
+      Consider the following scenarios
+      --------------------------------
+
+      code change in repo |
+      EHRBASE	    SDK     |   BRANCH          |   CI ACTION       |   COMMENT
+      --------------------|-------------------|-------------------|---------------------------------------------------------------------
+
+      YES	        NO	        feature/*           default build	      ehrbase uses SDK referenced in it's parent pom.xml	(commit hash)
+      NO	        YES	        feature/*	          default build	      sdk uses EHRBASE (built) from develop branch
+
+      YES	        YES	        feature/*	          SHOULD FAIL		      default builds triggered on both CIs do not take into account
+                                                                      respective changes in the featue branch of the other repository
+                                                                      NOTE: if the build does NOT fail on ehrbase's and/or sdk's CI
+                                                                            then proper Java unit/integration tests are missing!
+
+      YES	        NO	        sync/feature/*	    SHOULD FAIL	        ehrbase's CI fails to checkout sync/feature/* branch from sdk repo
+      NO 	        YES	        sync/feature/*	    SHOULD FAIL	        sdk's CI fails to checkout sync/feature/* branch from ehrbase repo
+
+      YES	        YES	        sync/feature/*	    synced build	      - ehrbase's CI uses SDK from sync/feature/* branch
+                                                                      - sdk's CI uses EHRBASE from sync/feature/* branch
+
+      explanations        
+      --------------------	
+      default build (ehrbase)		EHRbase is build using SDK version given in it's parent pom.xml
+      default build (sdk)		    SDK is build and tested using EHRbase build from develop branch
+
+      synced build                both CIs take into account respective changes in sync/feature/*
+                                  branch of each repository
+
+      Find detailed steps description for this workflow in
+      "build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK" job.
+
+
+      HOW TO USE THIS WORKFLOW?
+      =========================
+
+      1. create TWO branches "sync/[issue-id]_name branches" respectively in
+
+        - ehrbase repo       --> i.e.    sync/123_example-issue
+        - openehr_sdk repo   --> i.e.    sync/123_example-issue
+
+      2. apply and commit your code changes (!!! in both repositories)
+      3. push to openehr_sdk repo (CI will trigger this workflow)
+      4. push to ehrbase repo (ehrbase's CI will trigger a similar workflow)
+
+       NOTE: at this point 'synced build' will be trigger on both CIs
+
+      5. create TWO PRs (one in ehrbase, one in openehr_sdk)
+      6. merge bot PRs (WARNING):
+
+      ///////////////////////////////////////////////////////////////////////
+      ///                                                                 ///
+      ///  - make sure that both PRs are reviewed and ready to be merged  ///
+      ///    at the same time!                                            ///
+      ///  - make sure to sync both PRs w/ develop before merging!        ///
+      ///  - open each PR in it's own browser window                      ///
+      ///  - MERGE BOTH PRs AT THE SAME TIME!                             ///
+      ///                                                                 ///
+      //////////////////////////////////////////////////////////////////////
+
+
     jobs:
-      - build-and-test-openEHR_SDK:
+      - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK:
           context: org-global
           filters:
             branches:
               only:
                 - /^sync\/.*/
                 - /^feature\/sync\/.*/
+      - COMPOSITION-tests-1:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - COMPOSITION-tests-2:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - COMPOSITION-tests-3:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - COMPOSITION-tests-4:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - CONTRIBUTION-tests:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - DIRECTORY-tests:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - EHRSERVICE-tests:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - EHRSTATUS-tests:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - KNOWLEDGE-tests:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - QUERYSERVICE-tests-1:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - QUERYSERVICE-tests-2:
+          context: org-global
+          requires:
+            - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      # - SECURITY-test:
+      #     context: org-global
+      #     requires:
+      #       - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      # - ADMIN-test:
+      #     context: org-global
+      #     requires:
+      #       - build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK
+      - ROBOT-TEST-REPORT:
+          context: org-global
+          requires:
+            - COMPOSITION-tests-1
+            - COMPOSITION-tests-2
+            - COMPOSITION-tests-3
+            - COMPOSITION-tests-4
+            - CONTRIBUTION-tests
+            - DIRECTORY-tests
+            - EHRSERVICE-tests
+            - EHRSTATUS-tests
+            - KNOWLEDGE-tests
+            - QUERYSERVICE-tests-1
+            - QUERYSERVICE-tests-2
+            # - SECURITY-test
+            # - ADMIN-test
 
 
 
@@ -295,7 +456,7 @@ jobs:
       - checkout
       - cache-out-sdk-m2-dependencies
       - build-sdk
-      - git-clone-ehrbase-repo
+      - git-clone-ehrbase-repo:
           branch: ${CIRCLE_BRANCH}
       - cache-out-ehrbase-m2-dependencies
       - force-ehrbase-build-to-use-local-sdk-version
@@ -951,7 +1112,7 @@ commands:
             git clone git@github.com:ehrbase/ehrbase.git
             ls -la
             cd ehrbase
-            git checkout << parameters.brach >>
+            git checkout << parameters.branch >>
   
 
   build-and-test-ehrbase:


### PR DESCRIPTION
WHAT THIS WORKFLOW DOES
      =======================

      Build and run all openEHR_SDK Java tests (unit and integration tests)
      with EHRbase being checked out from a branch named sync/* or sync/feature/*

      Consider the following scenarios
      --------------------------------

      code change in repo |
      EHRBASE	    SDK     |   BRANCH          |   CI ACTION       |   COMMENT
      --------------------|-------------------|-------------------|---------------------------------------------------------------------

      YES	        NO	        feature/*           default build	      ehrbase uses SDK referenced in it's parent pom.xml	(commit hash)
      NO	        YES	        feature/*	          default build	      sdk uses EHRBASE (built) from develop branch

      YES	        YES	        feature/*	          SHOULD FAIL		      default builds triggered on both CIs do not take into account
                                                                      respective changes in the featue branch of the other repository
                                                                      NOTE: if the build does NOT fail on ehrbase's and/or sdk's CI
                                                                            then proper Java unit/integration tests are missing!

      YES	        NO	        sync/feature/*	    SHOULD FAIL	        ehrbase's CI fails to checkout sync/feature/* branch from sdk repo
      NO 	        YES	        sync/feature/*	    SHOULD FAIL	        sdk's CI fails to checkout sync/feature/* branch from ehrbase repo

      YES	        YES	        sync/feature/*	    synced build	      - ehrbase's CI uses SDK from sync/feature/* branch
                                                                      - sdk's CI uses EHRBASE from sync/feature/* branch

      explanations        
      --------------------	
      default build (ehrbase)		EHRbase is build using SDK version given in it's parent pom.xml
      default build (sdk)		    SDK is build and tested using EHRbase build from develop branch

      synced build                both CIs take into account respective changes in sync/feature/*
                                  branch of each repository

      Find detailed steps description for this workflow in
      "build-and-test-synced-branches-of-EHRbase-and-openEHR_SDK" job.


      HOW TO USE THIS WORKFLOW?
      =========================

      1. create TWO branches "sync/[issue-id]_name branches" respectively in

        - ehrbase repo       --> i.e.    sync/123_example-issue
        - openehr_sdk repo   --> i.e.    sync/123_example-issue

      2. apply and commit your code changes (!!! in both repositories)
      3. push to openehr_sdk repo (CI will trigger this workflow)
      4. push to ehrbase repo (ehrbase's CI will trigger a similar workflow)

       NOTE: at this point 'synced build' will be trigger on both CIs

      5. create TWO PRs (one in ehrbase, one in openehr_sdk)
      6. merge bot PRs (WARNING):

      ///////////////////////////////////////////////////////////////////////
      ///                                                                 ///
      ///  - make sure that both PRs are reviewed and ready to be merged  ///
      ///    at the same time!                                            ///
      ///  - make sure to sync both PRs w/ develop before merging!        ///
      ///  - open each PR in it's own browser window                      ///
      ///  - MERGE BOTH PRs AT THE SAME TIME!                             ///
      ///                                                                 ///
      //////////////////////////////////////////////////////////////////////