### PR TITLE
removed name json encoding

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/CodePhraseAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/CodePhraseAdapter.java
@@ -28,6 +28,7 @@ import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.support.identification.TerminologyId;
 import org.ehrbase.serialisation.dbencoding.wrappers.json.I_DvTypeAdapter;
 import org.ehrbase.serialisation.util.ObjectSnakeCase;
+import org.ehrbase.serialisation.util.SnakeCase;
 
 import java.io.IOException;
 
@@ -66,18 +67,19 @@ public class CodePhraseAdapter extends DvTypeAdapter<CodePhrase> {
         if (adapterType == I_DvTypeAdapter.AdapterType.PG_JSONB) {
             writer.beginObject();
             writer.name("codeString").value(codePhrase.getCodeString());
+            writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(CodePhrase.class.getSimpleName()).camelToUpperSnake());
             writer.name("terminologyId");
             writer.beginObject();
-            writer.name("name").value(codePhrase.getTerminologyId().getValue());
             writer.name("value").value(codePhrase.getTerminologyId().getValue());
+            writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(TerminologyId.class.getSimpleName()).camelToUpperSnake());
             writer.endObject();
             writer.endObject();
         } else if (adapterType == I_DvTypeAdapter.AdapterType.RAW_JSON) {
-            writer.beginObject(); //{
+            writer.beginObject();
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new ObjectSnakeCase(codePhrase).camelToUpperSnake());
             writer.name("code_string").value(codePhrase.getCodeString());
             writer.name("terminology_id").value(gson.toJson(codePhrase.getTerminologyId()));
-            writer.endObject(); //}
+            writer.endObject();
         }
 
     }

--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/DvCodedTextAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/DvCodedTextAdapter.java
@@ -65,27 +65,18 @@ public class DvCodedTextAdapter extends DvTypeAdapter<DvCodedText> {
             return;
         }
 
-//		"value": "complete blood count",
-//				"definingCode": {
-//			"codeString": "26604007",
-//					"terminologyId": {
-//				"name": "SNOMED-CT",
-//						"value": "SNOMED-CT"
-//			}
-//		}
         TermMappingAdapter termMappingAdapter = new TermMappingAdapter();
 
         if (adapterType == I_DvTypeAdapter.AdapterType.PG_JSONB) {
             writer.beginObject();
-            writer.name("value").value(dvalue.getValue());
+            writer.name(VALUE).value(dvalue.getValue());
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(DvCodedText.class.getSimpleName()).camelToUpperSnake());
             writer.name("definingCode");
             writer.beginObject();
             writer.name("codeString").value(dvalue.getDefiningCode().getCodeString());
             writer.name("terminologyId");
             writer.beginObject();
-            writer.name("name").value(dvalue.getDefiningCode().getTerminologyId().getValue());
-            writer.name("value").value(dvalue.getDefiningCode().getTerminologyId().getValue());
+            writer.name(VALUE).value(dvalue.getDefiningCode().getTerminologyId().getValue());
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(TerminologyId.class.getSimpleName()).camelToUpperSnake());
             writer.endObject();
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(CodePhrase.class.getSimpleName()).camelToUpperSnake());
@@ -95,7 +86,7 @@ public class DvCodedTextAdapter extends DvTypeAdapter<DvCodedText> {
         } else if (adapterType == I_DvTypeAdapter.AdapterType.RAW_JSON) {
             writer.beginObject();
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new ObjectSnakeCase(dvalue).camelToUpperSnake());
-            writer.name("value").value(dvalue.getValue());
+            writer.name(VALUE).value(dvalue.getValue());
             CodePhrase codePhrase = dvalue.getDefiningCode();
             writer.name("defining_code").value(gson.toJson(codePhrase));
             writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new SnakeCase(CodePhrase.class.getSimpleName()).camelToUpperSnake());


### PR DESCRIPTION
This fix remove the name (operation, not an attribute) in canonical TERMINOLOGY_ID rendering.

Fixes: https://github.com/ehrbase/project_management/issues/465