### PR TITLE
allow opt-out on specific attributes in canonical json

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/CompositionSerializer.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/CompositionSerializer.java
@@ -112,6 +112,7 @@ public class CompositionSerializer {
   public static final String TAG_LINKS = "/links";
   public static final String DEFAULT_NARRATIVE = "DEFAULT_NARRATIVE";
   public static final String TAG_ARCHETYPE_DETAILS = "/archetype_details";
+  public static final String EPOCH_OFFSET = "epoch_offset";
   public static final DvText NO_NAME = null;
 
   public CompositionSerializer() {

--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/translator_db2raw/LinkedTreeMapAdapter.java
@@ -295,6 +295,10 @@ public class LinkedTreeMapAdapter extends TypeAdapter<LinkedTreeMap<String, Obje
       if (value == null) continue;
 
       String key = entry.getKey();
+
+      if (new OptOut(key).skipIt())
+        continue;
+
       String jsonKey = new RawJsonKey(key).toRawJson();
       final String archetypeNodeId = new NodeId(key).predicate();
 

--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/translator_db2raw/OptOut.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/translator_db2raw/OptOut.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Christian Chevalley (Hannover Medical School) and Vitasystems GmbH
+ *
+ * This file is part of project EHRbase
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.ehrbase.serialisation.dbencoding.wrappers.json.writer.translator_db2raw;
+
+import org.ehrbase.serialisation.dbencoding.CompositionSerializer;
+
+import java.util.Arrays;
+
+/**
+ * deals with opt-out attributes (f.e. epoch_offset)
+ */
+public class OptOut {
+
+    private final String tag;
+    private String[] optOutTag = {CompositionSerializer.EPOCH_OFFSET};
+
+    public OptOut(String tag){
+        this.tag = tag;
+    }
+
+    public boolean skipIt(){
+        return Arrays.asList(optOutTag).contains(tag);
+    }
+
+}


### PR DESCRIPTION
removed epoch_offset from canonical DvDateTime rendering.

Fixes: https://github.com/ehrbase/project_management/issues/408

NB. The test fails due to unresolved https://github.com/ehrbase/project_management/issues/361. This means that until the recommended step is not done, this change cannot be merged.