### PR TITLE
force duration for DvDuration boundaries

### DIFF
--- a/validation/src/main/java/org/ehrbase/validation/constraints/wrappers/IntervalComparator.java
+++ b/validation/src/main/java/org/ehrbase/validation/constraints/wrappers/IntervalComparator.java
@@ -244,17 +244,23 @@ public class IntervalComparator {
 
         Duration lowerDuration, upperDuration;
         //Date massage...
-        if (lower != null)
-            lowerDuration = Duration.parse(lower);
-        else
-            lowerDuration = Duration.ZERO;
+        //A period is not comparable (cannot compare days and months as depending on actual month...)
+        try {
+            if (lower != null)
+                lowerDuration = Duration.parse(lower);
+            else
+                lowerDuration = Duration.ZERO;
 
-        if (upper != null)
-            upperDuration = Duration.parse(upper);
-        else
-            upperDuration = Duration.of(Long.MAX_VALUE, ChronoUnit.FOREVER);
+            if (upper != null)
+                upperDuration = Duration.parse(upper);
+            else
+                upperDuration = Duration.of(Long.MAX_VALUE, ChronoUnit.FOREVER);
 
-        compareWithinInterval(valueDuration, intervalOfDuration, lowerDuration, upperDuration);
+            compareWithinInterval(valueDuration, intervalOfDuration, lowerDuration, upperDuration);
+        }
+        catch (Exception e){
+            throw new IllegalArgumentException("Boundaries are invalid, please make sure that only durations are specified. Found: lower:"+lower+", upper:"+upper);
+        }
     }
 
     public static boolean isOptional(IntervalOfInteger intervalOfInteger) {


### PR DESCRIPTION
This fix check that DvDuration interval set as boundaries in a template is using DURATION (and not PERIOD). The reason is that a PERIOD cannot be normalized for comparison: 1M could hold value of 28D, 29D, 30D, 31D. The same for year vs days.

Hence, whenever boundaries are defined there should be DURATION only, that is "PT...".

Fixes: https://github.com/ehrbase/ehrbase/issues/427