### PR TITLE
use custom serializer for DvDateTime

### DIFF
--- a/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/systematic/SpecialCase.java
+++ b/client/src/test/java/org/ehrbase/client/openehrclient/defaultrestclient/systematic/SpecialCase.java
@@ -48,18 +48,10 @@ public class SpecialCase {
         }
         else  if (object instanceof Temporal || object instanceof Duration || object instanceof URI) {
             retObject = object.toString();
-            if (object instanceof Temporal){
-                //align the millisec delimiter
-                if (retObject instanceof String && ((String) retObject).contains("."))
-                    retObject = ((String)retObject).replace(".", ",");
-            }
         }
         else if (object instanceof Integer)
             //this is a hack as a Long is transformed as Integer in the HTTP response?
             retObject = Integer.toUnsignedLong((Integer)object);
-        else if (object instanceof String &&
-                ((String)object).matches("^\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?$"))
-            retObject = ((String)retObject).replace(".", ",");
         else if (object instanceof String &&
                 ((String)object).contains("PARTY_SELF"))
             retObject = "PARTY_SELF";

--- a/client/src/test/resources/testsets/arbitrary/date_time_where_tests.csv
+++ b/client/src/test/resources/testsets/arbitrary/date_time_where_tests.csv
@@ -1,5 +1,5 @@
 # the path is quoted as it contains a comma (csv delimiter)
-date_time_tests_select.txt, "o/data[at0001]/events[at0002]/data[at0003]/items[at0011]/value/value = '2019-01-28T21:22:49,427+07:00'",Test all types
+date_time_tests_select.txt, o/data[at0001]/events[at0002]/data[at0003]/items[at0011]/value/value = '2019-01-28T21:22:49.427+07:00',Test all types
 
 # test comparison with partial date/time
 date_time_tests_select.txt, o/data[at0001]/events[at0002]/data[at0003]/items[at0011]/value/value > '2021' AND o/data[at0001]/events[at0002]/data[at0003]/items[at0011]/value/value < '2022',

--- a/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/CanonicalJson.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/CanonicalJson.java
@@ -28,12 +28,14 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.jsontype.impl.ClassNameIdResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.nedap.archie.base.OpenEHRBase;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.archetyped.*;
 import com.nedap.archie.rm.datastructures.History;
+import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
 import com.nedap.archie.rm.support.identification.ArchetypeID;
 import com.nedap.archie.rm.support.identification.UIDBasedId;
 import com.nedap.archie.rminfo.ArchieAOMInfoLookup;
@@ -66,6 +68,10 @@ public class CanonicalJson implements RMDataFormat {
             om.addMixInAnnotations(Locatable.class, LocatableMixIn.class);
             om.addMixInAnnotations(Pathable.class, PathableMixIn.class);
             om.addMixInAnnotations(UIDBasedId.class, UIDBasedIdMixIn.class);
+
+            SimpleModule module = new SimpleModule();
+            module.addSerializer(DvDateTime.class, new DateTimeSerializer());
+            om.registerModule(module);
 
             // Global configuration to not include empty lists in the JSON
             om.setSerializationInclusion(Include.NON_EMPTY);
@@ -221,6 +227,7 @@ public class CanonicalJson implements RMDataFormat {
             super(TypeFactory.defaultInstance().constructType(OpenEHRBase.class), TypeFactory.defaultInstance());
         }
 
+        @Override
         public JsonTypeInfo.Id getMechanism() {
             return JsonTypeInfo.Id.NAME;
         }
@@ -238,11 +245,6 @@ public class CanonicalJson implements RMDataFormat {
             } else {
                 return rmInfoLookup.getNamingStrategy().getTypeName(value.getClass());
             }
-            // This should work in all cases for openEHR-classes and this should not be used for other classes
-            // Additional code for making this work on non-ehr-types:
-            //        } else {
-            //            return super.idFromValue(value);
-            //        }
         }
 
         @Override

--- a/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/DateTimeSerializer.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/DateTimeSerializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Christian Chevalley (Hannover Medical School) and Vitasystems GmbH
+ *
+ * This file is part of project EHRbase
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.ehrbase.serialisation.jsonencoding;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DecimalStyle;
+
+import static com.nedap.archie.datetime.DateTimeSerializerFormatters.ISO_8601_DATE;
+import static com.nedap.archie.datetime.DateTimeSerializerFormatters.ISO_8601_TIME;
+
+/**
+ * custom serializer for DvDateTime instance with dot delimiter instead of comma
+ */
+public class DateTimeSerializer extends JsonSerializer<DvDateTime> {
+
+    public static final DateTimeFormatter ISO_8601_DATE_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_8601_DATE)
+            .appendLiteral('T')
+            .append(ISO_8601_TIME)
+            .toFormatter()
+            .withDecimalStyle(DecimalStyle.STANDARD.withDecimalSeparator('.'));
+
+    @Override
+    public void serialize(DvDateTime dvDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        toJson(jsonGenerator, dvDateTime);
+        }
+
+    @Override
+    public void serializeWithType(DvDateTime dvDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider, TypeSerializer typeSer) throws IOException {
+        toJson(jsonGenerator, dvDateTime);
+    }
+
+    private void toJson(JsonGenerator jsonGenerator, DvDateTime dvDateTime) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("_type", "DV_DATE_TIME");
+        jsonGenerator.writeStringField("value", ISO_8601_DATE_TIME.format(dvDateTime.getValue()));
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/serialisation/src/test/java/org/ehrbase/serialisation/jsonencoding/CanonicalJsonMarshallingTest.java
+++ b/serialisation/src/test/java/org/ehrbase/serialisation/jsonencoding/CanonicalJsonMarshallingTest.java
@@ -136,4 +136,17 @@ public class CanonicalJsonMarshallingTest {
         Ehr actual = cut.unmarshal(json, Ehr.class);
         Assert.assertEquals(actual, expected);
     }
+
+    //check that dot is not converted into a comma!
+    @Test
+    public void MarshalDvDateTime() {
+        DvDateTime dvDateTime = new DvDateTime("2021-10-01T10:32:51.543+07:00");
+        CanonicalJson cut = new CanonicalJson();
+        String actual = cut.marshal(dvDateTime);
+        assertThat(actual).isEqualToIgnoringWhitespace("{" +
+                "  \"_type\" : \"DV_DATE_TIME\"," +
+                "  \"value\" : \"2021-10-01T10:32:51.543+07:00\"" +
+                "}");
+
+    }
 }


### PR DESCRIPTION
This change normalize DOT as decimal separator in ISO8601 datetime representation whenever milliseconds are present. That is:

```
2021-10-01T10:32:51.543+07:00
```
Canonical json is now properly encoded (previously due to Archie serialization, the delimiter was a COMMA).

This fixes: https://github.com/ehrbase/project_management/issues/453
