### PR TITLE
ensure Dr. House is unique across tests!

### DIFF
--- a/test-data/src/main/resources/composition/canonical_json/minimal_instruction.json
+++ b/test-data/src/main/resources/composition/canonical_json/minimal_instruction.json
@@ -51,7 +51,7 @@
       "_type": "PARTY_REF",
       "id": {
         "_type": "HIER_OBJECT_ID",
-        "value": "638e55da-32db-42fa-8bb3-dafb685ad8a3"
+        "value": "b7c07d35-fa06-4280-8e65-eabdfbe64fdc"
       },
       "namespace": "DEMOGRAPHIC",
       "type": "PERSON"


### PR DESCRIPTION
Unless the DB is re-initialized between test sequences, make sure that party identified are consistent. Parties are not deleted when clearing EHRs as the entities are not strictly dependents. At this time a party might be created when posting a composition (f.e. composer), but in real life, this party should be identified from an identity management service for integrity purpose.