### PR TITLE
constrain encoding

### DIFF
--- a/serialisation/src/main/java/org/ehrbase/serialisation/attributes/LocatableAttributes.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/attributes/LocatableAttributes.java
@@ -19,10 +19,7 @@ package org.ehrbase.serialisation.attributes;
 
 import com.nedap.archie.rm.archetyped.Locatable;
 import org.apache.commons.collections.map.MultiValueMap;
-import org.ehrbase.serialisation.dbencoding.CompositionSerializer;
-import org.ehrbase.serialisation.dbencoding.ItemStack;
-import org.ehrbase.serialisation.dbencoding.NameAsDvText;
-import org.ehrbase.serialisation.dbencoding.NameInMap;
+import org.ehrbase.serialisation.dbencoding.*;
 
 import java.util.Map;
 
@@ -32,7 +29,7 @@ import static org.ehrbase.serialisation.dbencoding.CompositionSerializer.*;
  */
 public abstract class LocatableAttributes extends RMAttributes {
 
-  public LocatableAttributes(
+  protected LocatableAttributes(
       CompositionSerializer compositionSerializer, ItemStack itemStack, Map<String, Object> map) {
     super(compositionSerializer, itemStack, map);
   }
@@ -51,7 +48,7 @@ public abstract class LocatableAttributes extends RMAttributes {
       map.put(TAG_ARCHETYPE_NODE_ID, locatable.getArchetypeNodeId());
     }
     if (locatable.getArchetypeDetails() != null) {
-      map.put(TAG_ARCHETYPE_DETAILS, locatable.getArchetypeDetails());
+      map.put(TAG_ARCHETYPE_DETAILS, new RmObjectEncoding(locatable.getArchetypeDetails()).toMap());
     }
     if (locatable.getFeederAudit() != null) {
       map.put(TAG_FEEDER_AUDIT, new FeederAuditAttributes(locatable.getFeederAudit()).toMap());

--- a/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/JacksonUtil.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/jsonencoding/JacksonUtil.java
@@ -25,6 +25,10 @@ import com.nedap.archie.json.RMJacksonConfiguration;
 
 public class JacksonUtil {
 
+    private JacksonUtil() {
+        //for sonarlint...
+    }
+
     /**
      * Get an object mapper that works with Archie RM and AOM objects. It will be cached in a static variable for
      * performance reasons
@@ -33,6 +37,7 @@ public class JacksonUtil {
      */
     public static ObjectMapper getObjectMapper() {
         RMJacksonConfiguration configuration = new RMJacksonConfiguration();
+        configuration.setAddExtraFieldsInArchetypeId(false);
         configuration.setTypePropertyName("_type");
         configuration.setSerializeEmptyCollections(true);
         return com.nedap.archie.json.JacksonUtil.getObjectMapper(configuration);


### PR DESCRIPTION
Constrained json encoding to remove the operations (aka. attributes) unexpected in archetype_id (see https://specifications.openehr.org/releases/UML/latest/#Architecture___18_5_1_83e026d_1503073094506_395796_7676) 

fixes: https://github.com/ehrbase/ehrbase/issues/446
fixes: https://github.com/ehrbase/project_management/issues/586