### PR TITLE
added missing type attribute in jsonb encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 - Fix issue when template does not contain list of values for DV_ORDINAL (https://github.com/ehrbase/openEHR_SDK/pull/295)
 - Fix issue in AQL regarding LIMIT and OFFSET (https://github.com/ehrbase/openEHR_SDK/pull/296)
 - Fix issue while unmarshalling FLAT composition that contains ELEMENT with children DV_CODED_TEXT and DV_TEXT (https://github.com/ehrbase/openEHR_SDK/pull/300)
-- Fix missing 'type' attribute in ExternalRef encoding ()
+- Fix missing 'type' attribute in ExternalRef encoding (https://github.com/ehrbase/openEHR_SDK/pull/303)
 - 
 ## 1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 - Fix issue when template does not contain list of values for DV_ORDINAL (https://github.com/ehrbase/openEHR_SDK/pull/295)
 - Fix issue in AQL regarding LIMIT and OFFSET (https://github.com/ehrbase/openEHR_SDK/pull/296)
 - Fix issue while unmarshalling FLAT composition that contains ELEMENT with children DV_CODED_TEXT and DV_TEXT (https://github.com/ehrbase/openEHR_SDK/pull/300)
+- Fix missing 'type' attribute in ExternalRef encoding ()
 - 
 ## 1.16.0
 

--- a/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/PartyRefAdapter.java
+++ b/serialisation/src/main/java/org/ehrbase/serialisation/dbencoding/wrappers/json/writer/PartyRefAdapter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  */
 public class PartyRefAdapter extends DvTypeAdapter<PartyRef> {
 
-    private Gson gson;
+    private final Gson gson;
 
     public PartyRefAdapter(AdapterType adapterType) {
         super(adapterType);
@@ -66,20 +66,13 @@ public class PartyRefAdapter extends DvTypeAdapter<PartyRef> {
         if (adapterType == AdapterType.PG_JSONB) {
             writer.beginObject();
             writer.name("namespace").value(partyRef.getNamespace());
+            writer.name("type").value(partyRef.getType());
             writer.name(CompositionSerializer.TAG_CLASS).value(PartyRef.class.getSimpleName());
             if (partyRef.getId() != null){
                 writer.name("id").jsonValue(gson.toJson(partyRef.getId()));
             }
             //TODO: add Identifiers
             writer.endObject();
-        } else if (adapterType == AdapterType.RAW_JSON) {
-//
-//            writer.beginObject(); //{
-//            writer.name(I_DvTypeAdapter.TAG_CLASS_RAW_JSON).value(new ObjectSnakeCase(participation).camelToUpperSnake());
-//            writer.name("value").value(participation.getValue());
-//            CodePhrase codePhrase = participation.getDefiningCode();
-//            writer.name("defining_code").value(gson.toJson(codePhrase));
-//            writer.endObject(); //}
         }
 
     }

--- a/serialisation/src/test/java/org/ehrbase/serialisation/dbencoding/DBEncodeTest.java
+++ b/serialisation/src/test/java/org/ehrbase/serialisation/dbencoding/DBEncodeTest.java
@@ -847,4 +847,26 @@ public class DBEncodeTest {
         Assert.assertNotNull(expiryTime);
         Assert.assertEquals(OffsetDateTime.parse("2021-05-18T13:13:09.780+03:00"), expiryTime.getValue());
     }
+
+    @Test
+    public void testOtherParticipationsPartyRef() throws IOException {
+        Composition composition = new CanonicalJson().unmarshal(IOUtils.toString(CompositionTestDataCanonicalJson.OTHER_PARTICIPATIONS.getStream(), UTF_8),Composition.class);
+
+        assertNotNull(composition);
+
+        CompositionSerializer compositionSerializerRawJson = new CompositionSerializer();
+
+        String db_encoded = compositionSerializerRawJson.dbEncode(composition);
+        assertNotNull(db_encoded);
+
+        JsonElement converted = new LightRawJsonEncoder(db_encoded).encodeContentAsJson("composition");
+
+        //see if this can be interpreted by Archie
+        Composition composition2 = new CanonicalJson().unmarshal(converted.toString(), Composition.class);
+
+        assertNotNull(composition2);
+
+        assertEquals("PERSON",composition2.itemsAtPath("/content[openEHR-EHR-ACTION.minimal.v1]/other_participations/performer/external_ref/type").get(0));
+    }
+
 }


### PR DESCRIPTION
This is simply adding the attribute `type` to json ExternalRef serialization.

fixes: https://github.com/ehrbase/ehrbase/issues/729