### PR TITLE
Feature/cdr 1198 query response meta props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
 ## [unreleased]
- ### Added 
+ ### Added
+- Added `QueryResponseData.meta` additional `fetch`, `offset` and `resultsize` properties ([#559](https://github.com/ehrbase/openEHR_SDK/pull/559))
  ### Fixed 
 
 ## [2.6.0]
  ### Changed
 - Bumped libraries
  ### Added 
-- Added `QueryResponseData.meta` additional `fetch`, `offset` and `resultsize` properties ([#559](https://github.com/ehrbase/openEHR_SDK/pull/559))
  ### Fixed 
 - Parsing of string function CONTAINS ([5ef1eca](https://github.com/ehrbase/openEHR_SDK/commit/5ef1eca72289856fa94a04146aa876a4c5130423))
 - Add missing aggregate function name to the parser ([8fd08bb](https://github.com/ehrbase/openEHR_SDK/commit/8fd08bbd1ce3b5a217cc8e2b701e32c2125bf0bf))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ## [2.6.0]
  ### Changed
 - Bumped libraries
+ ### Added 
+- Added `QueryResponseData.meta` optional `_fetch` and `_offset` properties ([#559](https://github.com/ehrbase/openEHR_SDK/pull/559))
  ### Fixed 
 - Parsing of string function CONTAINS ([5ef1eca](https://github.com/ehrbase/openEHR_SDK/commit/5ef1eca72289856fa94a04146aa876a4c5130423))
 - Add missing aggregate function name to the parser ([8fd08bb](https://github.com/ehrbase/openEHR_SDK/commit/8fd08bbd1ce3b5a217cc8e2b701e32c2125bf0bf))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
  ### Changed
 - Bumped libraries
  ### Added 
-- Added `QueryResponseData.meta` optional `_fetch` and `_offset` properties ([#559](https://github.com/ehrbase/openEHR_SDK/pull/559))
+- Added `QueryResponseData.meta` additional `fetch`, `offset` and `resultsize` properties ([#559](https://github.com/ehrbase/openEHR_SDK/pull/559))
  ### Fixed 
 - Parsing of string function CONTAINS ([5ef1eca](https://github.com/ehrbase/openEHR_SDK/commit/5ef1eca72289856fa94a04146aa876a4c5130423))
 - Add missing aggregate function name to the parser ([8fd08bb](https://github.com/ehrbase/openEHR_SDK/commit/8fd08bbd1ce3b5a217cc8e2b701e32c2125bf0bf))

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -72,7 +72,7 @@
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
         <jacoco.version>0.8.11</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
                             <on>@format:on</on>
                         </toggleOffOn>
                         <palantirJavaFormat>
-                            <version>2.24.0</version>
+                            <version>2.39.0</version>
                         </palantirJavaFormat>
                         <licenseHeader>
                             <file>${license-header.dir}/license-header</file>

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
@@ -62,11 +62,11 @@ public class MetaData {
         this.executedAql = queryResultDto.getExecutedAQL();
 
         // apply _fetch/_offset as needed - note in case only a limit was used we define the default offset 0L
-        Long limit = queryResultDto.getLimit();
-        Long offset = queryResultDto.getOffset();
-        if (limit != null) {
-            this.fetch = limit;
-            this.offset = offset != null ? offset : 0L;
+        Long resultLimit = queryResultDto.getLimit();
+        Long resultOffset = queryResultDto.getOffset();
+        if (resultLimit != null) {
+            this.fetch = resultLimit;
+            this.offset = resultOffset != null ? resultOffset : 0L;
         }
         // setHref() and setSchemaVersion() needs to be specified by the application
         this.href = null;

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
@@ -17,10 +17,14 @@
  */
 package org.ehrbase.openehr.sdk.response.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryResultDto;
 
 public class MetaData {
+
+    public static final String RESULTSET = "RESULTSET";
 
     @JsonProperty(value = "_href")
     private String href;
@@ -39,6 +43,36 @@ public class MetaData {
 
     @JsonProperty(value = "_executed_aql")
     private String executedAql;
+
+    @JsonProperty(value = "_fetch")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long fetch;
+
+    @JsonProperty(value = "_offset")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long offset;
+
+    public MetaData() {}
+
+    public MetaData(QueryResultDto queryResultDto) {
+
+        // initialize basic response meta data
+        this.type = MetaData.RESULTSET;
+        this.created = queryResultDto.getCreated();
+        this.executedAql = queryResultDto.getExecutedAQL();
+
+        // apply _fetch/_offset as needed - note in case only a limit was used we define the default offset 0L
+        Long limit = queryResultDto.getLimit();
+        Long offset = queryResultDto.getOffset();
+        if (limit != null) {
+            this.fetch = limit;
+            this.offset = offset != null ? offset : 0L;
+        }
+        // setHref() and setSchemaVersion() needs to be specified by the application
+        this.href = null;
+        this.schemaVersion = null;
+        this.generator = null;
+    }
 
     public String getHref() {
         return href;
@@ -86,5 +120,39 @@ public class MetaData {
 
     public void setExecutedAql(String executedAql) {
         this.executedAql = executedAql;
+    }
+
+    /**
+     * Extracted from the query <code>fetch</code> parameter or from the server default.
+     * <pre>
+     * Not part of the standard spec, but returned by openEHR since version <code>1.0.0</code> for debugging purposes.
+     * </pre>
+     */
+    public Long getFetch() {
+        return fetch;
+    }
+
+    /**
+     * @see #getFetch()
+     */
+    public void setFetch(Long fetch) {
+        this.fetch = fetch;
+    }
+
+    /**
+     * Extracted from the query <code>limit</code> parameter.
+     * <pre>
+     * Not part of the standard spec, but returned by openEHR since version <code>1.0.0</code> for debugging purposes.
+     * </pre>
+     */
+    public Long getOffset() {
+        return offset;
+    }
+
+    /**
+     * @see #getOffset()
+     */
+    public void setOffset(Long offset) {
+        this.offset = offset;
     }
 }

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
@@ -20,6 +20,8 @@ package org.ehrbase.openehr.sdk.response.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryResultDto;
 
 public class MetaData {
@@ -44,13 +46,17 @@ public class MetaData {
     @JsonProperty(value = "_executed_aql")
     private String executedAql;
 
-    @JsonProperty(value = "_fetch")
+    @JsonProperty(value = "fetch")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long fetch;
 
-    @JsonProperty(value = "_offset")
+    @JsonProperty(value = "offset")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long offset;
+
+    @JsonProperty(value = "resultsize")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer resultSize;
 
     public MetaData() {}
 
@@ -60,6 +66,11 @@ public class MetaData {
         this.type = MetaData.RESULTSET;
         this.created = queryResultDto.getCreated();
         this.executedAql = queryResultDto.getExecutedAQL();
+
+        // we always add the response set size - also in case it is empty
+        this.resultSize = Optional.ofNullable(queryResultDto.getResultSet())
+                .map(List::size)
+                .orElse(0);
 
         // apply _fetch/_offset as needed - note in case only a limit was used we define the default offset 0L
         Long resultLimit = queryResultDto.getLimit();
@@ -154,5 +165,19 @@ public class MetaData {
      */
     public void setOffset(Long offset) {
         this.offset = offset;
+    }
+
+    /**
+     * Size of the returned rows.
+     */
+    public Integer getResultSize() {
+        return resultSize;
+    }
+
+    /**
+     * @see #getResultSize()
+     */
+    public void setResultSize(Integer resultSize) {
+        this.resultSize = resultSize;
     }
 }

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/MetaData.java
@@ -52,15 +52,6 @@ public class MetaData {
         String getName();
 
         @FunctionalInterface
-        interface LongProperty extends AdditionalProperty<Long> {
-
-            @Override
-            default Long apply(Object o) {
-                return o instanceof Number ? ((Number) o).longValue() : null;
-            }
-        }
-
-        @FunctionalInterface
         interface IntegerProperty extends AdditionalProperty<Integer> {
 
             @Override
@@ -75,7 +66,7 @@ public class MetaData {
          * Not part of the standard spec, but returned by openEHR since version <code>1.0.0</code> for debugging purposes.
          * </pre>
          */
-        LongProperty fetch = () -> "fetch";
+        IntegerProperty fetch = () -> "fetch";
 
         /**
          * Extracted from the query <code>limit</code> parameter.
@@ -83,7 +74,7 @@ public class MetaData {
          * Not part of the standard spec, but returned by openEHR since version <code>1.0.0</code> for debugging purposes.
          * </pre>
          */
-        LongProperty offset = () -> "offset";
+        IntegerProperty offset = () -> "offset";
 
         /**
          * Size of the returned rows.
@@ -131,11 +122,11 @@ public class MetaData {
                         .orElse(0));
 
         // apply fetch/offset as needed - note in case only a limit was used we define the default offset as0L
-        Long resultLimit = queryResultDto.getLimit();
-        Long resultOffset = queryResultDto.getOffset();
+        Integer resultLimit = queryResultDto.getLimit();
+        Integer resultOffset = queryResultDto.getOffset();
         if (resultLimit != null) {
             setAdditionalProperty(AdditionalProperty.fetch, resultLimit);
-            setAdditionalProperty(AdditionalProperty.offset, resultOffset != null ? resultOffset : 0L);
+            setAdditionalProperty(AdditionalProperty.offset, resultOffset != null ? resultOffset : 0);
         }
         // the following properties needs to be specified by the application
         this.href = null;

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/QueryResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/QueryResponseData.java
@@ -31,6 +31,8 @@ import org.ehrbase.openehr.sdk.response.dto.ehrscape.query.ResultHolder;
 @JacksonXmlRootElement
 public class QueryResponseData {
 
+    @JsonProperty(value = "meta")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private MetaData meta;
 
     // the initial query without substitution (!)
@@ -44,11 +46,16 @@ public class QueryResponseData {
     // the list of columns as defined in the SELECT clause (with a path...)
     @JsonProperty(value = "columns")
     private List<Map<String, String>> columns;
+
     // the actual resultset
     @JsonProperty(value = "rows")
     private List<List<Object>> rows;
 
     public QueryResponseData(QueryResultDto queryResultDto) {
+
+        this.meta = null;
+
+        // TODO response `q` property shall be the in initial request query, not the executed one with substitution
         this.query = queryResultDto.getExecutedAQL();
         this.name = null;
 

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryResultDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryResultDto.java
@@ -26,8 +26,8 @@ public class QueryResultDto {
 
     private OffsetDateTime created;
     private String executedAQL;
-    private Long limit;
-    private Long offset;
+    private Integer limit;
+    private Integer offset;
     private List<List<String>> explain;
     private Map<String, String> variables;
     private List<ResultHolder> resultSet;
@@ -64,19 +64,19 @@ public class QueryResultDto {
         this.executedAQL = executedAQL;
     }
 
-    public @Nullable Long getLimit() {
+    public @Nullable Integer getLimit() {
         return limit;
     }
 
-    public void setLimit(Long limit) {
+    public void setLimit(Integer limit) {
         this.limit = limit;
     }
 
-    public @Nullable Long getOffset() {
+    public @Nullable Integer getOffset() {
         return offset;
     }
 
-    public void setOffset(Long offset) {
+    public void setOffset(Integer offset) {
         this.offset = offset;
     }
 

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryResultDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryResultDto.java
@@ -17,16 +17,36 @@
  */
 package org.ehrbase.openehr.sdk.response.dto.ehrscape;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.time.OffsetDateTime;
+import java.util.*;
+import javax.annotation.Nullable;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.query.ResultHolder;
 
 public class QueryResultDto {
+
+    private OffsetDateTime created;
     private String executedAQL;
+    private Long limit;
+    private Long offset;
     private List<List<String>> explain;
     private Map<String, String> variables;
     private List<ResultHolder> resultSet;
+
+    public QueryResultDto() {
+        this(OffsetDateTime.now());
+    }
+
+    public QueryResultDto(OffsetDateTime created) {
+        this.created = created;
+    }
+
+    public OffsetDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(OffsetDateTime created) {
+        this.created = created;
+    }
 
     public List<ResultHolder> getResultSet() {
         return resultSet;
@@ -42,6 +62,22 @@ public class QueryResultDto {
 
     public void setExecutedAQL(String executedAQL) {
         this.executedAQL = executedAQL;
+    }
+
+    public @Nullable Long getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Long limit) {
+        this.limit = limit;
+    }
+
+    public @Nullable Long getOffset() {
+        return offset;
+    }
+
+    public void setOffset(Long offset) {
+        this.offset = offset;
     }
 
     public List<List<String>> getExplain() {
@@ -61,7 +97,7 @@ public class QueryResultDto {
     }
 
     public boolean variablesIsEmpty() {
-        return variables.size() == 0;
+        return Optional.ofNullable(variables).orElse(Collections.emptyMap()).isEmpty();
     }
 
     public boolean variablesContainsColumnId(String columnId) {
@@ -73,6 +109,6 @@ public class QueryResultDto {
     }
 
     public Iterator<Map.Entry<String, String>> variablesIterator() {
-        return variables.entrySet().iterator();
+        return getVariables().entrySet().iterator();
     }
 }

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/JacksonTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/JacksonTest.java
@@ -18,22 +18,14 @@
 package org.ehrbase.openehr.sdk.response.dto;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.ehrbase.openehr.sdk.response.dto.util.JacksonTestUtil.objectMapper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class JacksonTest {
-
-    private final ObjectMapper objectMapper;
-
-    public JacksonTest() {
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-    }
 
     @Test
     void testReadJson() throws IOException {

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
@@ -64,9 +64,9 @@ public class MetaDataTest {
         metaData.setGenerator("DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)");
         metaData.setExecutedAql("SELECT e/ehr_id/value FROM EHR e");
         // debug info
-        metaData.setOffset(100L);
-        metaData.setFetch(50L);
-        metaData.setResultSize(42);
+        metaData.setAdditionalProperty(MetaData.AdditionalProperty.fetch, 50L);
+        metaData.setAdditionalProperty(MetaData.AdditionalProperty.offset, 100L);
+        metaData.setAdditionalProperty(MetaData.AdditionalProperty.resultSize, 42);
 
         String json = objectMapper.writeValueAsString(metaData);
 
@@ -101,9 +101,9 @@ public class MetaDataTest {
 
         assertNull(metaData.getHref());
         assertNull(metaData.getGenerator());
-        assertNull(metaData.getFetch());
-        assertNull(metaData.getOffset());
-        assertNull(metaData.getResultSize());
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch));
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset));
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize));
 
         assertEquals(MetaData.RESULTSET, metaData.getType());
         assertEquals("1.0.4", metaData.getSchemaVersion());
@@ -140,9 +140,9 @@ public class MetaDataTest {
         assertEquals(
                 "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)", metaData.getGenerator());
         assertEquals("SELECT e/ehr_id/value FROM EHR e", metaData.getExecutedAql());
-        assertEquals(50, metaData.getFetch());
-        assertEquals(100, metaData.getOffset());
-        assertEquals(20, metaData.getResultSize());
+        assertEquals(50, metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch));
+        assertEquals(100, metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset));
+        assertEquals(20, metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize));
     }
 
     @Test
@@ -154,8 +154,9 @@ public class MetaDataTest {
 
         assertNotNull(metaData);
 
-        assertNull(metaData.getFetch());
-        assertNull(metaData.getOffset());
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch));
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset));
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize));
 
         assertEquals("... the URI for the executed AQL - used only for GET executions ...", metaData.getHref());
         assertEquals(
@@ -180,10 +181,10 @@ public class MetaDataTest {
         assertEquals(
                 metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC),
                 OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00").atZoneSameInstant(ZoneOffset.UTC));
-        assertEquals(metaData.getResultSize(), 0);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize), 0);
 
-        assertNull(metaData.getFetch());
-        assertNull(metaData.getOffset());
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch));
+        assertNull(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset));
         assertNull(metaData.getHref());
         assertNull(metaData.getGenerator());
     }
@@ -197,9 +198,9 @@ public class MetaDataTest {
         }));
 
         assertNotNull(metaData, "Expected meta to be null");
-        assertEquals(metaData.getFetch(), 100L);
-        assertEquals(metaData.getOffset(), 0L);
-        assertEquals(metaData.getResultSize(), 0);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 0L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize), 0);
     }
 
     @Test
@@ -212,8 +213,8 @@ public class MetaDataTest {
         }));
 
         assertNotNull(metaData, "Expected meta to be null");
-        assertEquals(metaData.getFetch(), 100L);
-        assertEquals(metaData.getOffset(), 50L);
-        assertEquals(metaData.getResultSize(), 0);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 50L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize), 0);
     }
 }

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
@@ -64,8 +64,8 @@ public class MetaDataTest {
         metaData.setGenerator("DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)");
         metaData.setExecutedAql("SELECT e/ehr_id/value FROM EHR e");
         // debug info
-        metaData.setAdditionalProperty(MetaData.AdditionalProperty.fetch, 50L);
-        metaData.setAdditionalProperty(MetaData.AdditionalProperty.offset, 100L);
+        metaData.setAdditionalProperty(MetaData.AdditionalProperty.fetch, 50);
+        metaData.setAdditionalProperty(MetaData.AdditionalProperty.offset, 100);
         metaData.setAdditionalProperty(MetaData.AdditionalProperty.resultSize, 42);
 
         String json = objectMapper.writeValueAsString(metaData);
@@ -194,12 +194,12 @@ public class MetaDataTest {
 
         MetaData metaData = new MetaData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
             resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
-            resultDto.setLimit(100L);
+            resultDto.setLimit(100);
         }));
 
         assertNotNull(metaData, "Expected meta to be null");
-        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100L);
-        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 0L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 0);
         assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize), 0);
     }
 
@@ -208,13 +208,13 @@ public class MetaDataTest {
 
         MetaData metaData = new MetaData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
             resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
-            resultDto.setLimit(100L);
-            resultDto.setOffset(50L);
+            resultDto.setLimit(100);
+            resultDto.setOffset(50);
         }));
 
         assertNotNull(metaData, "Expected meta to be null");
-        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100L);
-        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 50L);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.fetch), 100);
+        assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.offset), 50);
         assertEquals(metaData.getAdditionalProperty(MetaData.AdditionalProperty.resultSize), 0);
     }
 }

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2024 vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project openEHR_SDK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.openehr.sdk.response.dto;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.ehrbase.openehr.sdk.response.dto.util.JacksonTestUtil.objectMapper;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.apache.commons.io.IOUtils;
+import org.ehrbase.openehr.sdk.response.dto.util.DTOFixtures;
+import org.junit.jupiter.api.Test;
+
+public class MetaDataTest {
+
+    @Test
+    void serializedJSONMinimal() throws JsonProcessingException {
+
+        MetaData metaData = new MetaData();
+        metaData.setType(MetaData.RESULTSET);
+        metaData.setSchemaVersion("1.0.4");
+        metaData.setCreated(OffsetDateTime.parse("2017-08-19T00:25:47.568+02:00"));
+        metaData.setExecutedAql("SELECT e/ehr_id/value FROM EHR e");
+
+        String json = objectMapper.writeValueAsString(metaData);
+
+        assertEquals(
+                """
+                        {
+                          "_type" : "RESULTSET",
+                          "_schema_version" : "1.0.4",
+                          "_created" : "2017-08-19T00:25:47.568+02:00",
+                          "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e"
+                        }""",
+                json);
+    }
+
+    @Test
+    void serializedJSON() throws JsonProcessingException {
+
+        MetaData metaData = new MetaData();
+        metaData.setHref("https://example.com/subpath/ehrbase/rest/openehr/v1/query/aql");
+        metaData.setType(MetaData.RESULTSET);
+        metaData.setSchemaVersion("1.0.4");
+        metaData.setCreated(OffsetDateTime.parse("2017-08-19T12:30:00.568+02:00"));
+        metaData.setGenerator("DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)");
+        metaData.setExecutedAql("SELECT e/ehr_id/value FROM EHR e");
+        // debug info
+        metaData.setOffset(100L);
+        metaData.setFetch(50L);
+
+        String json = objectMapper.writeValueAsString(metaData);
+
+        assertEquals(
+                """
+                        {
+                          "_href" : "https://example.com/subpath/ehrbase/rest/openehr/v1/query/aql",
+                          "_type" : "RESULTSET",
+                          "_schema_version" : "1.0.4",
+                          "_created" : "2017-08-19T12:30:00.568+02:00",
+                          "_generator" : "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)",
+                          "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e",
+                          "_fetch" : 50,
+                          "_offset" : 100
+                        }""",
+                json);
+    }
+
+    @Test
+    void deserializedJSONMinimal() throws JsonProcessingException {
+
+        MetaData metaData = objectMapper.readValue(
+                """
+                        {
+                          "_type" : "RESULTSET",
+                          "_schema_version" : "1.0.4",
+                          "_created" : "2017-08-19T00:25:47.568+02:00",
+                          "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e"
+                        }""",
+                MetaData.class);
+
+        assertNull(metaData.getHref());
+        assertNull(metaData.getGenerator());
+        assertNull(metaData.getFetch());
+        assertNull(metaData.getOffset());
+
+        assertEquals(MetaData.RESULTSET, metaData.getType());
+        assertEquals("1.0.4", metaData.getSchemaVersion());
+        assertEquals(
+                OffsetDateTime.parse("2017-08-19T00:25:47.568+02:00").atZoneSameInstant(ZoneOffset.UTC),
+                metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC));
+        assertEquals("SELECT e/ehr_id/value FROM EHR e", metaData.getExecutedAql());
+    }
+
+    @Test
+    void deserializeJSON() throws JsonProcessingException {
+
+        MetaData metaData = objectMapper.readValue(
+                """
+                        {
+                          "_href" : "https://example.com/ehrbase/rest/openehr/v1/query/aql",
+                          "_type" : "RESULTSET",
+                          "_schema_version" : "1.0.4",
+                          "_created" : "2017-08-19T00:25:47.568+02:00",
+                          "_generator" : "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)",
+                          "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e",
+                          "_fetch" : 50,
+                          "_offset" : 100
+                        }""",
+                MetaData.class);
+
+        assertEquals("https://example.com/ehrbase/rest/openehr/v1/query/aql", metaData.getHref());
+        assertEquals(MetaData.RESULTSET, metaData.getType());
+        assertEquals("1.0.4", metaData.getSchemaVersion());
+        assertEquals(
+                OffsetDateTime.parse("2017-08-19T00:25:47.568+02:00").atZoneSameInstant(ZoneOffset.UTC),
+                metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC));
+        assertEquals(
+                "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)", metaData.getGenerator());
+        assertEquals("SELECT e/ehr_id/value FROM EHR e", metaData.getExecutedAql());
+        assertEquals(50, metaData.getFetch());
+        assertEquals(100, metaData.getOffset());
+    }
+
+    @Test
+    void deserializeRealWorldExample() throws IOException {
+
+        QueryResponseData queryResponseData = objectMapper.readValue(
+                IOUtils.resourceToString("/query_response.json", UTF_8), QueryResponseData.class);
+        MetaData metaData = queryResponseData.getMeta();
+
+        assertNotNull(metaData);
+
+        assertNull(metaData.getFetch());
+        assertNull(metaData.getOffset());
+
+        assertEquals("... the URI for the executed AQL - used only for GET executions ...", metaData.getHref());
+        assertEquals(
+                OffsetDateTime.parse("2017-08-19T00:25:47.568+02:00").atZoneSameInstant(ZoneOffset.UTC),
+                metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC));
+        assertEquals(
+                "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)", metaData.getGenerator());
+        assertEquals("1.0.0", metaData.getSchemaVersion());
+        assertEquals("... the executed aql ...", metaData.getExecutedAql());
+    }
+
+    @Test
+    void fromQueryResult() {
+
+        MetaData metaData = new MetaData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
+            resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
+        }));
+
+        assertNotNull(metaData, "Expected meta to be null");
+        assertEquals(metaData.getType(), "RESULTSET");
+        assertEquals(metaData.getExecutedAql(), "SELECT e/ehr_id/value FROM EHR e LIMIT 100 OFFSET 1");
+        assertEquals(
+                metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC),
+                OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00").atZoneSameInstant(ZoneOffset.UTC));
+
+        assertNull(metaData.getFetch());
+        assertNull(metaData.getOffset());
+        assertNull(metaData.getHref());
+        assertNull(metaData.getGenerator());
+    }
+
+    @Test
+    void fromQueryResultDoesContainFetchDefaultOffset() {
+
+        MetaData metaData = new MetaData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
+            resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
+            resultDto.setLimit(100L);
+        }));
+
+        assertNotNull(metaData, "Expected meta to be null");
+        assertEquals(metaData.getFetch(), 100L);
+        assertEquals(metaData.getOffset(), 0L);
+    }
+
+    @Test
+    void fromQueryResultContainsFetchOffset() {
+
+        MetaData metaData = new MetaData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
+            resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
+            resultDto.setLimit(100L);
+            resultDto.setOffset(50L);
+        }));
+
+        assertNotNull(metaData, "Expected meta to be null");
+        assertEquals(metaData.getFetch(), 100L);
+        assertEquals(metaData.getOffset(), 50L);
+    }
+}

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/MetaDataTest.java
@@ -66,6 +66,7 @@ public class MetaDataTest {
         // debug info
         metaData.setOffset(100L);
         metaData.setFetch(50L);
+        metaData.setResultSize(42);
 
         String json = objectMapper.writeValueAsString(metaData);
 
@@ -78,8 +79,9 @@ public class MetaDataTest {
                           "_created" : "2017-08-19T12:30:00.568+02:00",
                           "_generator" : "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)",
                           "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e",
-                          "_fetch" : 50,
-                          "_offset" : 100
+                          "fetch" : 50,
+                          "offset" : 100,
+                          "resultsize" : 42
                         }""",
                 json);
     }
@@ -101,6 +103,7 @@ public class MetaDataTest {
         assertNull(metaData.getGenerator());
         assertNull(metaData.getFetch());
         assertNull(metaData.getOffset());
+        assertNull(metaData.getResultSize());
 
         assertEquals(MetaData.RESULTSET, metaData.getType());
         assertEquals("1.0.4", metaData.getSchemaVersion());
@@ -122,8 +125,9 @@ public class MetaDataTest {
                           "_created" : "2017-08-19T00:25:47.568+02:00",
                           "_generator" : "DIPS.OpenEhr.ResultSets.Serialization.Json.ResultSetJsonWriter (5.0.0.0)",
                           "_executed_aql" : "SELECT e/ehr_id/value FROM EHR e",
-                          "_fetch" : 50,
-                          "_offset" : 100
+                          "fetch" : 50,
+                          "offset" : 100,
+                          "resultsize": 20
                         }""",
                 MetaData.class);
 
@@ -138,6 +142,7 @@ public class MetaDataTest {
         assertEquals("SELECT e/ehr_id/value FROM EHR e", metaData.getExecutedAql());
         assertEquals(50, metaData.getFetch());
         assertEquals(100, metaData.getOffset());
+        assertEquals(20, metaData.getResultSize());
     }
 
     @Test
@@ -175,6 +180,7 @@ public class MetaDataTest {
         assertEquals(
                 metaData.getCreated().atZoneSameInstant(ZoneOffset.UTC),
                 OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00").atZoneSameInstant(ZoneOffset.UTC));
+        assertEquals(metaData.getResultSize(), 0);
 
         assertNull(metaData.getFetch());
         assertNull(metaData.getOffset());
@@ -193,6 +199,7 @@ public class MetaDataTest {
         assertNotNull(metaData, "Expected meta to be null");
         assertEquals(metaData.getFetch(), 100L);
         assertEquals(metaData.getOffset(), 0L);
+        assertEquals(metaData.getResultSize(), 0);
     }
 
     @Test
@@ -207,5 +214,6 @@ public class MetaDataTest {
         assertNotNull(metaData, "Expected meta to be null");
         assertEquals(metaData.getFetch(), 100L);
         assertEquals(metaData.getOffset(), 50L);
+        assertEquals(metaData.getResultSize(), 0);
     }
 }

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/QueryResponseDataTest.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/QueryResponseDataTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2024 vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project openEHR_SDK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.openehr.sdk.response.dto;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.ehrbase.openehr.sdk.response.dto.util.JacksonTestUtil.objectMapper;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.*;
+import org.apache.commons.io.IOUtils;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.query.ResultHolder;
+import org.ehrbase.openehr.sdk.response.dto.util.DTOFixtures;
+import org.junit.jupiter.api.Test;
+
+class QueryResponseDataTest {
+
+    @Test
+    void serializedJSONMinimal() throws JsonProcessingException {
+
+        QueryResponseData queryResponseData = new QueryResponseData();
+        queryResponseData.setQuery("SELECT e/ehr_id/value FROM EHR e");
+        queryResponseData.setColumns(Collections.emptyList());
+        queryResponseData.setRows(Collections.emptyList());
+
+        String json = objectMapper.writeValueAsString(queryResponseData);
+
+        assertEquals(
+                """
+                        {
+                          "q" : "SELECT e/ehr_id/value FROM EHR e",
+                          "columns" : [ ],
+                          "rows" : [ ]
+                        }""",
+                json);
+    }
+
+    @Test
+    void serializedJSON() throws JsonProcessingException {
+
+        QueryResponseData queryResponseData = new QueryResponseData();
+        queryResponseData.setQuery("SELECT e/ehr_id/value FROM EHR e");
+        queryResponseData.setName("all.ehr.ids::query");
+        queryResponseData.setColumns(List.of(new TreeMap<>(Map.of(
+                "path", "e/ehr_id/value",
+                "name", "#0"))));
+        queryResponseData.setRows(List.of(List.of("c631b8d4-c2b7-4908-812f-83403b4c866d")));
+
+        var metaData = new MetaData();
+        metaData.setType("RESULTSET");
+        metaData.setSchemaVersion("1.0.4");
+        metaData.setCreated(OffsetDateTime.parse("2024-01-10T12:30:00.123456+01:00"));
+        metaData.setExecutedAql("SELECT e/ehr_id/value FROM EHR LIMIT 100 OFFSET 0");
+        queryResponseData.setMeta(metaData);
+
+        String json = objectMapper.writeValueAsString(queryResponseData);
+
+        assertEquals(
+                """
+                        {
+                          "meta" : {
+                            "_type" : "RESULTSET",
+                            "_schema_version" : "1.0.4",
+                            "_created" : "2024-01-10T12:30:00.123456+01:00",
+                            "_executed_aql" : "SELECT e/ehr_id/value FROM EHR LIMIT 100 OFFSET 0"
+                          },
+                          "q" : "SELECT e/ehr_id/value FROM EHR e",
+                          "name" : "all.ehr.ids::query",
+                          "columns" : [ {
+                            "name" : "#0",
+                            "path" : "e/ehr_id/value"
+                          } ],
+                          "rows" : [ [ "c631b8d4-c2b7-4908-812f-83403b4c866d" ] ]
+                        }""",
+                json);
+    }
+
+    @Test
+    void deserializedJSONMinimal() throws JsonProcessingException {
+
+        QueryResponseData queryResponseData = objectMapper.readValue(
+                """
+                        {
+                          "q" : "SELECT e/ehr_id/value FROM EHR e",
+                          "columns" : [ ],
+                          "rows" : [ ]
+                        }""",
+                QueryResponseData.class);
+
+        assertNull(queryResponseData.getMeta());
+        assertNull(queryResponseData.getName());
+        assertEquals("SELECT e/ehr_id/value FROM EHR e", queryResponseData.getQuery());
+        assertEquals(Collections.emptyList(), queryResponseData.getColumns());
+        assertEquals(Collections.emptyList(), queryResponseData.getRows());
+    }
+
+    @Test
+    void deserializeJSON() throws JsonProcessingException {
+
+        QueryResponseData queryResponseData = objectMapper.readValue(
+                """
+                        {
+                          "meta" : {
+                            "_type" : "RESULTSET",
+                            "_schema_version" : "1.0.4",
+                            "_created" : "2024-01-10T12:30:00.123456+01:00",
+                            "_executed_aql" : "SELECT e/ehr_id/value FROM EHR LIMIT 100 OFFSET 0"
+                          },
+                          "q" : "SELECT e/ehr_id/value FROM EHR e",
+                          "name" : "all.ehr.ids::query",
+                          "columns" : [ {
+                            "name" : "#0",
+                            "path" : "e/ehr_id/value"
+                          } ],
+                          "rows" : [ [ "c631b8d4-c2b7-4908-812f-83403b4c866d" ] ]
+                        }""",
+                QueryResponseData.class);
+
+        assertNotNull(queryResponseData.getMeta());
+        assertEquals("all.ehr.ids::query", queryResponseData.getName());
+        assertEquals("SELECT e/ehr_id/value FROM EHR e", queryResponseData.getQuery());
+        List<Map<String, String>> columns = queryResponseData.getColumns();
+        {
+            assertEquals(1, columns.size());
+            Map<String, String> column = columns.get(0);
+            assertEquals(2, column.size());
+            assertEquals("#0", column.get("name"));
+            assertEquals("e/ehr_id/value", column.get("path"));
+        }
+        List<List<Object>> rows = queryResponseData.getRows();
+        {
+            assertEquals(1, rows.size());
+            assertEquals(List.of("c631b8d4-c2b7-4908-812f-83403b4c866d"), rows.get(0));
+        }
+    }
+
+    @Test
+    void deserializeRealWorldExample() throws IOException {
+
+        QueryResponseData queryResponseData = objectMapper.readValue(
+                IOUtils.resourceToString("/query_response.json", UTF_8), QueryResponseData.class);
+        assertNotNull(queryResponseData.getMeta());
+        assertEquals(
+                "SELECT e/ehr_id/value, c/context/start_time/value as startTime, c/uid/value as cid, c/name FROM EHR e CONTAINS COMPOSITION c[openEHR-EHR-COMPOSITION.encounter.v1] CONTAINS OBSERVATION obs[openEHR-EHR-OBSERVATION.blood_pressure.v1] WHERE obs/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude >= $systolic_bp",
+                queryResponseData.getQuery());
+        assertEquals(
+                "... the name or identifier of the stored query that was executed ...", queryResponseData.getName());
+
+        List<Map<String, String>> columns = queryResponseData.getColumns();
+        assertEquals(4, columns.size(), "Expected 4 columns to exist");
+        assertColumnNameWithPath(columns.get(0), "#0", "/ehr_id/value");
+        assertColumnNameWithPath(columns.get(1), "startTime", "/context/start_time/value");
+        assertColumnNameWithPath(columns.get(2), "cid", "/uid/value");
+        assertColumnNameWithPath(columns.get(3), "#3", "/name");
+
+        List<List<Object>> rows = queryResponseData.getRows();
+        assertEquals(1, rows.size(), "Expected one row to exist");
+        {
+            List<Object> result = rows.get(0);
+            assertEquals(4, result.size(), "Row need 4 entries");
+            assertEquals("81433066-c417-4813-9b29-79783e7bed23", result.get(0));
+            assertEquals("2017-02-16T13:50:11.308+01:00", result.get(1));
+            assertEquals("90910cf0-66a0-4382-b1f8-c0f27e81b42d::openEHRSys.example.com::1", result.get(2));
+            assertEquals(Map.of("_type", "DV_TEXT", "value", "Labs"), result.get(3));
+        }
+    }
+
+    @Test
+    void fromQueryResultUsesExecutedAql() {
+
+        QueryResponseData queryResponseData = new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto());
+
+        // for now the response `q` property contains the executed AQL query with substitution
+        assertEquals("SELECT e/ehr_id/value FROM EHR e LIMIT 100 OFFSET 1", queryResponseData.getQuery());
+
+        // TODO response `q` property shall be the in initial request query, not the executed one with substitution
+        // assertNull(queryResponseData.getQuery(), "Expected query to be null");
+    }
+
+    @Test
+    void fromQueryResultDoesNotContainMetaData() {
+
+        QueryResponseData queryResponseData =
+                new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto(resultDto -> {
+                    resultDto.setCreated(OffsetDateTime.parse("2017-02-16T13:50:11.308+01:00"));
+                }));
+
+        assertNull(queryResponseData.getMeta(), "Expected meta to be null");
+    }
+
+    @Test
+    void fromQueryResultDoesContainName() {
+
+        QueryResponseData queryResponseData = new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto());
+
+        assertNull(queryResponseData.getName(), "Expected name to be null");
+    }
+
+    @Test
+    void fromQueryResultNothingSelected() {
+
+        QueryResponseData queryResponseData = new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto(dto -> {
+            dto.setVariables(null);
+            dto.setResultSet(null);
+        }));
+
+        assertTrue(queryResponseData.getColumns().isEmpty(), "Expected no result columns");
+        assertTrue(queryResponseData.getRows().isEmpty(), "Expected result rows");
+    }
+
+    @Test
+    void fromQueryResultEmptyResult() {
+
+        QueryResponseData queryResponseData = new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto(dto -> {
+            dto.setVariables(Map.of("#0", "e/ehr_id/value"));
+            dto.setResultSet(Collections.emptyList());
+        }));
+
+        List<Map<String, String>> columns = queryResponseData.getColumns();
+        assertEquals(1, columns.size(), "Expected one column to exist");
+        assertColumnNameWithPath(columns.get(0), "#0", "e/ehr_id/value");
+
+        assertTrue(queryResponseData.getRows().isEmpty(), "Expected result rows");
+    }
+
+    @Test
+    void fromQueryResultSingleEntry() {
+
+        QueryResponseData queryResponseData = new QueryResponseData(DTOFixtures.fixtureQueryResultResultDto(dto -> {
+            dto.setVariables(Map.of("#0", "e/ehr_id/value"));
+
+            ResultHolder resultHolder = new ResultHolder();
+            resultHolder.putResult("#0", UUID.fromString("c631b8d4-c2b7-4908-812f-83403b4c866d"));
+            dto.setResultSet(List.of(resultHolder));
+        }));
+
+        List<Map<String, String>> columns = queryResponseData.getColumns();
+        assertEquals(columns.size(), 1, "Expected one column to exist");
+        assertColumnNameWithPath(columns.get(0), "#0", "e/ehr_id/value");
+
+        List<List<Object>> rows = queryResponseData.getRows();
+        assertEquals(1, rows.size(), "Expected one row to exist");
+        {
+            List<Object> result = rows.get(0);
+            assertEquals(1, result.size());
+            assertEquals(UUID.fromString("c631b8d4-c2b7-4908-812f-83403b4c866d"), result.get(0));
+        }
+    }
+
+    private static void assertColumnNameWithPath(Map<String, String> column, String name, String path) {
+        assertEquals(column.size(), 2);
+        assertEquals(name, column.get("name"));
+        assertEquals(path, column.get("path"));
+    }
+}

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/util/DTOFixtures.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/util/DTOFixtures.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project openEHR_SDK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.openehr.sdk.response.dto.util;
+
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryResultDto;
+
+public class DTOFixtures {
+
+    public static QueryResultDto fixtureQueryResultResultDto() {
+        return fixtureQueryResultResultDto(null);
+    }
+
+    public static QueryResultDto fixtureQueryResultResultDto(@Nullable Consumer<QueryResultDto> customize) {
+
+        QueryResultDto queryResultDto = new QueryResultDto();
+        queryResultDto.setExecutedAQL("SELECT e/ehr_id/value FROM EHR e LIMIT 100 OFFSET 1");
+
+        if (null != customize) {
+            customize.accept(queryResultDto);
+        }
+
+        return queryResultDto;
+    }
+}

--- a/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/util/JacksonTestUtil.java
+++ b/response-dto/src/test/java/org/ehrbase/openehr/sdk/response/dto/util/JacksonTestUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project openEHR_SDK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.openehr.sdk.response.dto.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class JacksonTestUtil {
+
+    public static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT); // make test assert more readable
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL); // omit null values
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+}


### PR DESCRIPTION
# Changes

Extend the `QueryResponseData.meta` response object to map also the additional `fetch`, `offset` amd `resultsize` properties, that are supported by `EHRBase 1.0.0`. Further more adde `limit` and `offset` to the ehrscape `QueryResultDto` to be able to pass such informations in EHRBase. 
Now a `MetaData` object can be constructed from `QueryResponseData` that contains all basic properties.

# Additional information 

* Added unit tests for affected `QueryResponseData` and `MetaData` DTOs.  
* Bumped `palantirJavaFormat` to `2.24.0` to be able to use spotless with Java 21

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 