### PR TITLE
CDR-1388 Update flat marshalling of DvOrdered to be more resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,16 @@ In case there is a section of code that you carefully formatted in a special way
 ```
 everything here will be reformatted..
 
-// @formatter:off
+// @format:off
 
     This is not affected by spotless-plugin reformatting...
             And will stay as is it is!
 
-// @formatter:on
+// @format:on
 
 everything here will be reformatted..
 ```
-Please be aware that `@formatter:off/on` should only be used on rare occasions to increase readability of complex code and shall be looked at critically when reviewing merge requests.
+Please be aware that `@format:off/on` should only be used on rare occasions to increase readability of complex code and shall be looked at critically when reviewing merge requests.
 
 ----
 

--- a/serialisation/src/main/java/org/ehrbase/openehr/sdk/serialisation/flatencoding/std/marshal/config/DvOrdinalConfig.java
+++ b/serialisation/src/main/java/org/ehrbase/openehr/sdk/serialisation/flatencoding/std/marshal/config/DvOrdinalConfig.java
@@ -17,44 +17,36 @@
  */
 package org.ehrbase.openehr.sdk.serialisation.flatencoding.std.marshal.config;
 
-import com.nedap.archie.rm.datatypes.CodePhrase;
-import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.ehrbase.openehr.sdk.serialisation.walker.Context;
-import org.ehrbase.openehr.sdk.util.exception.SdkException;
-import org.ehrbase.openehr.sdk.webtemplate.model.WebTemplateInputValue;
 
 public class DvOrdinalConfig extends AbstractsStdConfig<DvOrdinal> {
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Class<DvOrdinal> getAssociatedClass() {
         return DvOrdinal.class;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Map<String, Object> buildChildValues(
-            String currentTerm, DvOrdinal rmObject, Context<Map<String, Object>> context) {
+            String currentTerm, DvOrdinal ordinal, Context<Map<String, Object>> context) {
+
         Map<String, Object> result = new HashMap<>();
-        String codeString = Optional.of(rmObject)
-                .map(DvOrdinal::getSymbol)
-                .map(DvCodedText::getDefiningCode)
-                .map(CodePhrase::getCodeString)
-                .orElse(null);
-        addValue(result, currentTerm, "code", codeString);
 
-        WebTemplateInputValue value = context.getNodeDeque().peek().getInputs().get(0).getList().stream()
-                .filter(o -> o.getValue().equals(codeString))
-                .findAny()
-                .orElseThrow(() -> new SdkException(String.format("Unknown Ordinal with code %s", codeString)));
-
-        addValue(result, currentTerm, "ordinal", value.getOrdinal());
-        addValue(result, currentTerm, "value", value.getLabel());
-
+        Optional.ofNullable(ordinal.getSymbol()).ifPresent(symbol -> {
+            addValue(result, currentTerm, "code", symbol.getDefiningCode().getCodeString());
+            addValue(result, currentTerm, "value", symbol.getValue());
+        });
+        addValue(result, currentTerm, "ordinal", ordinal.getValue());
         return result;
     }
 }

--- a/serialisation/src/test/java/org/ehrbase/openehr/sdk/serialisation/flatencoding/std/marshal/config/DvOrdinalConfigTest.java
+++ b/serialisation/src/test/java/org/ehrbase/openehr/sdk/serialisation/flatencoding/std/marshal/config/DvOrdinalConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 vitasystems GmbH and Hannover Medical School.
+ *
+ * This file is part of project openEHR_SDK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ehrbase.openehr.sdk.serialisation.flatencoding.std.marshal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nedap.archie.rm.datavalues.DvCodedText;
+import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
+import java.util.Map;
+import org.ehrbase.openehr.sdk.serialisation.walker.Context;
+import org.junit.jupiter.api.Test;
+
+class DvOrdinalConfigTest {
+
+    private Map<String, Object> buildChildValues(String currentTerm, DvOrdinal dvOrdinal) {
+        return new DvOrdinalConfig().buildChildValues(currentTerm, dvOrdinal, new Context<>());
+    }
+
+    @Test
+    void buildChildValuesOrdinalOnlySymbolNullSafe() {
+
+        Map<String, Object> childValues =
+                buildChildValues("nested:0/current_activity/ordinal", new DvOrdinal(1L, null));
+        assertThat(childValues).hasSize(1).containsEntry("nested:0/current_activity/ordinal|ordinal", 1L);
+    }
+
+    @Test
+    void buildChildValuesWithSymbol() {
+
+        Map<String, Object> childValues = buildChildValues(
+                "some_other/current_activity/ordinal", new DvOrdinal(42L, new DvCodedText("lorem ipsum", "PWVGUTHASM")));
+        assertThat(childValues)
+                .hasSize(3)
+                .containsEntry("some_other/current_activity/ordinal|ordinal", 42L)
+                .containsEntry("some_other/current_activity/ordinal|code", "PWVGUTHASM")
+                .containsEntry("some_other/current_activity/ordinal|value", "lorem ipsum");
+    }
+}


### PR DESCRIPTION
# Changes

Update flat marshalling of DvOrdered to be more resilient by not looking into the context.

also: corrected formatter usage in Readme so it now matches the values defined in the pom spotless config.

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 