### PR TITLE
Added the JsonSerDe-annotations to the path-object

### DIFF
--- a/aql/src/main/java/org/ehrbase/openehr/sdk/aql/dto/operand/IdentifiedPath.java
+++ b/aql/src/main/java/org/ehrbase/openehr/sdk/aql/dto/operand/IdentifiedPath.java
@@ -28,6 +28,8 @@ import org.ehrbase.openehr.sdk.aql.dto.containment.AbstractContainmentExpression
 import org.ehrbase.openehr.sdk.aql.dto.path.AndOperatorPredicate;
 import org.ehrbase.openehr.sdk.aql.dto.path.AqlObjectPath;
 import org.ehrbase.openehr.sdk.aql.render.AqlRenderer;
+import org.ehrbase.openehr.sdk.aql.serializer.ObjectPathDeserializer;
+import org.ehrbase.openehr.sdk.aql.serializer.ObjectPathSerializer;
 import org.ehrbase.openehr.sdk.aql.serializer.PredicateDeserializer;
 import org.ehrbase.openehr.sdk.aql.serializer.PredicateSerializer;
 
@@ -61,10 +63,12 @@ public final class IdentifiedPath implements ColumnExpression, Operand, Comparis
         this.rootPredicate = new ArrayList<>(rootPredicate);
     }
 
+    @JsonSerialize(using = ObjectPathSerializer.class)
     public AqlObjectPath getPath() {
         return path;
     }
 
+    @JsonDeserialize(using = ObjectPathDeserializer.class)
     public void setPath(AqlObjectPath path) {
         this.path = path;
     }


### PR DESCRIPTION
# Changes

Added the JsonSerDe-annotations to the path-object

# Related issue

The problem lies in the structure of the IdentifiedPath class. Within this class we have two options to handle the needed aql path (path and root). We send aql as json according to AqlQuery from openEHR.SDK.
