### PR TITLE
[CDR-1506] Deprecate DTOs/Data classes for EHR(_STATUS) used by EHRbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
 ## [unreleased]
+ ### Changed
+- Deprecated `response-dto` `EHR_(STATUS)` related classes that are only used by EHRbase ([621](https://github.com/ehrbase/openEHR_SDK/pull/621))
  ### Added 
  ### Fixed 
 

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ContributionCreateDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ContributionCreateDto.java
@@ -18,6 +18,7 @@
 package org.ehrbase.openehr.sdk.response.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.nedap.archie.rm.RMObject;
@@ -34,6 +35,7 @@ import javax.xml.bind.annotation.XmlType;
  * The duplicate of Contribution from com.nedap.archie.rm.changecontrol
  * with changed field versions list of ObjectRef to list of OriginalVersion.
  */
+@JsonRootName(value = "CONTRIBUTION")
 @XmlType(
         name = "CONTRIBUTION",
         propOrder = {"uid", "versions", "audit"})

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrResponseData.java
@@ -28,8 +28,11 @@ import org.ehrbase.openehr.sdk.response.dto.ehrscape.ContributionDto;
 
 /**
  * Basic set of response data regarding EHR operations. Used as default or when `PREFER` header requests minimal response.
+ *
+ * @deprecated without replaced because used by EHRbase only.
  */
 @JacksonXmlRootElement(localName = "ehr")
+@Deprecated(since = "2.14.0", forRemoval = true)
 public class EhrResponseData {
 
     @JsonProperty(value = "system_id")

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrResponseData.java
@@ -33,6 +33,7 @@ import org.ehrbase.openehr.sdk.response.dto.ehrscape.ContributionDto;
  */
 @JacksonXmlRootElement(localName = "ehr")
 @Deprecated(since = "2.14.0", forRemoval = true)
+@SuppressWarnings("java:S1133")
 public class EhrResponseData {
 
     @JsonProperty(value = "system_id")

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrStatusResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrStatusResponseData.java
@@ -27,8 +27,9 @@ import com.nedap.archie.rm.support.identification.UIDBasedId;
 /**
  * @deprecated without replaced because used by EHRbase only.
  */
-@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement(localName = "ehr_status")
+@Deprecated(since = "2.14.0", forRemoval = true)
+@SuppressWarnings("java:S1133")
 public class EhrStatusResponseData {
 
     @JsonProperty(value = "_type")

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrStatusResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/EhrStatusResponseData.java
@@ -24,6 +24,10 @@ import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.generic.PartySelf;
 import com.nedap.archie.rm.support.identification.UIDBasedId;
 
+/**
+ * @deprecated without replaced because used by EHRbase only.
+ */
+@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement(localName = "ehr_status")
 public class EhrStatusResponseData {
 

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedCompositionResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedCompositionResponseData.java
@@ -22,8 +22,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * @deprecated without replaced because used by EHRbase only.
  */
-@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement
+@Deprecated(since = "2.14.0", forRemoval = true)
+@SuppressWarnings("java:S1133")
 public class VersionedCompositionResponseData {
     // TODO only for stub for now. Need to change it to real RM versioned_composition or alike later! makes swagger-ui
     // fail right with: Maximum call stack size exceeded

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedCompositionResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedCompositionResponseData.java
@@ -19,6 +19,10 @@ package org.ehrbase.openehr.sdk.response.dto;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+/**
+ * @deprecated without replaced because used by EHRbase only.
+ */
+@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement
 public class VersionedCompositionResponseData {
     // TODO only for stub for now. Need to change it to real RM versioned_composition or alike later! makes swagger-ui

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedObjectResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedObjectResponseData.java
@@ -26,6 +26,10 @@ import com.nedap.archie.rm.support.identification.ObjectId;
 import com.nedap.archie.rm.support.identification.ObjectRef;
 import java.time.format.DateTimeFormatter;
 
+/**
+ * @deprecated without replaced because used by EHRbase only.
+ */
+@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement(localName = "ehr_status")
 @SuppressWarnings("java:S1452")
 public class VersionedObjectResponseData<T> {
@@ -52,8 +56,8 @@ public class VersionedObjectResponseData<T> {
         setType(CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, className));
         setUid(versionedObject.getUid());
         setOwnerId(versionedObject.getOwnerId());
-        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
-        setTimeCreated(formatter.format(versionedObject.getTimeCreated().getValue()));
+        setTimeCreated(DateTimeFormatter.ISO_DATE_TIME.format(
+                versionedObject.getTimeCreated().getValue()));
     }
 
     public String getType() {

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedObjectResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/VersionedObjectResponseData.java
@@ -29,9 +29,9 @@ import java.time.format.DateTimeFormatter;
 /**
  * @deprecated without replaced because used by EHRbase only.
  */
-@Deprecated(since = "2.14.0", forRemoval = true)
 @JacksonXmlRootElement(localName = "ehr_status")
-@SuppressWarnings("java:S1452")
+@Deprecated(since = "2.14.0", forRemoval = true)
+@SuppressWarnings({"java:S1133", "java:S1452"})
 public class VersionedObjectResponseData<T> {
 
     @JsonProperty(value = "_type")

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/EhrStatusDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/EhrStatusDto.java
@@ -17,6 +17,10 @@
  */
 package org.ehrbase.openehr.sdk.response.dto.ehrscape;
 
+/**
+ * @deprecated without replaced because used by EHRbase only.
+ */
+@Deprecated(since = "2.14.0", forRemoval = true)
 public class EhrStatusDto {
 
     String subjectId;

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/EhrStatusDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/EhrStatusDto.java
@@ -21,6 +21,7 @@ package org.ehrbase.openehr.sdk.response.dto.ehrscape;
  * @deprecated without replaced because used by EHRbase only.
  */
 @Deprecated(since = "2.14.0", forRemoval = true)
+@SuppressWarnings("java:S1133")
 public class EhrStatusDto {
 
     String subjectId;


### PR DESCRIPTION
# Changes

Some of the response DTOs/Data classes are only used by EHRbase. This PR deprecates them because they are now moved over to EHtbase itself https://github.com/ehrbase/ehrbase/pull/1377. 

# Pre-Merge checklist

- [x] New code is tested
- [x] Present and new tests pass
- [x] Documentation is updated
- [x] The build is working without errors
- [x] No new Sonar issues introduced
- [x] Changelog is updated
- [ ] Code has been reviewed 