### PR TITLE
Deprecate the outdated QueryDefinitionListResponseData class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ## [unreleased]
  ### Added 
  ### Fixed 
+* Deprecate the outdated QueryDefinitionListResponseData class ([#661](https://github.com/ehrbase/openEHR_SDK/pull/661))
 
 ## [2.20.0]
  ### Changed

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/QueryDefinitionListResponseData.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/QueryDefinitionListResponseData.java
@@ -26,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import org.ehrbase.openehr.sdk.response.dto.ehrscape.QueryDefinitionResultDto;
 
+/**
+ * @deprecated to be deleted as it will not be used by EHRbase anymore.
+ */
+@Deprecated(since = "2.21.0", forRemoval = true)
 @JacksonXmlRootElement
 public class QueryDefinitionListResponseData {
 


### PR DESCRIPTION
# Changes

Mark QueryDefinitionListResponseData as deprecated since version 2.21.0 for future removal. 
The class is no longer used by EHRbase and should be deleted in upcoming versions.

# Related issue

ehrbase/ehrbase#1456

# Additional information 

n/a

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 