### PR TITLE
fix #637 by defining two patterns

### DIFF
--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryDefinitionResultDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/QueryDefinitionResultDto.java
@@ -24,7 +24,7 @@ public class QueryDefinitionResultDto {
     private String qualifiedName;
     private String version;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.[SSS][SS]XXX")
     private ZonedDateTime saved;
 
     private String queryText;

--- a/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/TemplateMetaDataDto.java
+++ b/response-dto/src/main/java/org/ehrbase/openehr/sdk/response/dto/ehrscape/TemplateMetaDataDto.java
@@ -31,7 +31,7 @@ public class TemplateMetaDataDto {
 
     private String concept;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.[SSS][SS]XXX")
     @JsonProperty("created_timestamp")
     private OffsetDateTime createdOn;
 


### PR DESCRIPTION
# Changes

Define two optional patterns for `OffsetDateTime`, so either of them can be given. However, serialization is always done in the pattern `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`

# Related issue

#637 

# Additional information 

> Provide additional information for this change, if needed.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 