### PR TITLE
fix #701 parse negative durations

### DIFF
--- a/web-template/src/main/java/org/ehrbase/openehr/sdk/webtemplate/parser/InputHandler.java
+++ b/web-template/src/main/java/org/ehrbase/openehr/sdk/webtemplate/parser/InputHandler.java
@@ -471,7 +471,7 @@ public class InputHandler {
             char c = constrain.charAt(i);
             if (c == 'T') {
                 isDatePath = false;
-            } else if (CharUtils.isAsciiNumeric(c)) {
+            } else if (CharUtils.isAsciiNumeric(c) || c == '-') {
                 sb.append(c);
             } else if (c != 'P') {
                 String key = String.valueOf(c);


### PR DESCRIPTION
Negative durations results as shown here 
<img width="438" height="84" alt="image" src="https://github.com/user-attachments/assets/bca4af63-ad68-43d9-b04c-a81ec7a76cac" />

result in contrains like `-PT24H` which cannot be parsed at the moment. 


# Changes

parse negative durations by checking for negative signs in duration constrains

# Related issue

#701 

# Additional information 

> Provide additional information for this change, if needed.

# Pre-Merge checklist

- [ ] New code is tested
- [ ] Present and new tests pass
- [ ] Documentation is updated
- [ ] The build is working without errors
- [ ] No new Sonar issues introduced
- [ ] Changelog is updated
- [ ] Code has been reviewed 