### PR TITLE
Pass model lookup to Archie 3.19 validator

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@
         <sdkSubmoduleBuild>false</sdkSubmoduleBuild>
 
         <antlr4.version>4.13.2</antlr4.version>
-        <archie.version>3.13.0</archie.version>
+        <archie.version>3.19.0</archie.version>
         <assertj.version>3.27.7</assertj.version>
         <classgraph.version>4.8.192</classgraph.version>
         <commons-cli.version>1.11.0</commons-cli.version>

--- a/validation/src/main/java/org/ehrbase/openehr/sdk/validation/webtemplate/FastRMObjectValidator.java
+++ b/validation/src/main/java/org/ehrbase/openehr/sdk/validation/webtemplate/FastRMObjectValidator.java
@@ -94,7 +94,7 @@ public class FastRMObjectValidator extends RMObjectValidator {
      */
     @Deprecated
     public FastRMObjectValidator(ModelInfoLookup lookup, OperationalTemplateProvider provider) {
-        super(null, null, new ValidationConfiguration.Builder().build());
+        super(lookup, null, new ValidationConfiguration.Builder().build());
         this.lookup = lookup;
         this.metaModel = new MetaModel(lookup, null);
         constraintImposer = new ReflectionConstraintImposer(lookup);
@@ -120,7 +120,7 @@ public class FastRMObjectValidator extends RMObjectValidator {
             ModelInfoLookup lookup,
             OperationalTemplateProvider provider,
             ValidationConfiguration validationConfiguration) {
-        super(null, null, new ValidationConfiguration.Builder().build());
+        super(lookup, null, new ValidationConfiguration.Builder().build());
         this.lookup = lookup;
         this.metaModel = new MetaModel(lookup, null);
         constraintImposer = new ReflectionConstraintImposer(lookup);


### PR DESCRIPTION
# Changes

- Complete #761 by passing the existing `ModelInfoLookup` to Archie's
  `RMObjectValidator` from both `FastRMObjectValidator` constructors.
- Preserve the fast validator's existing template provider and validation
  configuration behavior.

# Related issue

#761

# Additional information

Archie 3.19 no longer accepts the previous null model lookup. The validator
already stores and uses the same lookup, so forwarding it to the superclass is
the smallest compatible migration.

Verification (JDK 21):

- `mvn -q -pl generator-commons,validation -am clean verify` — passed
- `git diff --check` — passed

# Pre-Merge checklist

- [x] New code is tested by the existing validation suites
- [x] Present and new tests pass for the affected modules
- [ ] Documentation is updated (not affected)
- [x] The affected-module build is working without errors
- [ ] No new Sonar issues introduced (awaiting repository CI)
- [ ] Changelog is updated (not needed for this compatibility fix)
- [ ] Code has been reviewed

Development assistance: prepared in Codex with the maintainer-intent,
fast-execution, and diff-review skills from
[JAIPilot](https://github.com/JAIPilot/jaipilot). Execution profile: `gpt-5.6-sol · xhigh · fast`. Execution was local.
